### PR TITLE
First version of dotnet zip, dotnet tarball

### DIFF
--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -3,6 +3,15 @@
     <TargetFramework>netstandard1.4</TargetFramework>
     <VersionPrefix>0.1.1</VersionPrefix>
     <NugetPackageFolder Condition="$(NugetPackageFolder) == ''">$(USERPROFILE)\.nuget\packages</NugetPackageFolder>
+    <Authors>Frederik Carlier</Authors>
+    <Company>Quamotion</Company>
+    <Product>Packaging Tools for .NET CLI</Product>
+    <Description>This package supports the dotnet-pack and dotnet-zip packages. Once you've installed this package together with dotnet-zip or dotnet-tarball, you can run commands such as dotnet zip or dotnet tarball to generate .zip or .tar.gz archives which contain the published output of your project.</Description>
+    <Copyright>Copyright (c) Frederik Carlier and Contributors</Copyright>
+    <PackageLicenseUrl>https://github.com/qmfrederik/dotnet-packaging/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/qmfrederik/dotnet-packaging/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/qmfrederik/dotnet-packaging/</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012" />

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -9,15 +9,14 @@
     <Compile Include="TarballTask.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="0.1.0-preview-00044-160929" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="0.1.0-preview-00044-160929" />
-    <PackageReference Include="NETStandard.Library" Version="1.6" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012" />
     <PackageReference Include="SharpZipLib.NETStandard" Version="0.86.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="build\*.*">
       <Pack>true</Pack>
-      <PackagePath>\</PackagePath>
+      <PackagePath>build\</PackagePath>
     </Content>
     <Content Include="$(NugetPackageFolder)\sharpziplib.netstandard\0.86.0.1\lib\netstandard1.3\SharpZipLib.NETStandard.dll" Link="false">
       <Pack>true</Pack>

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -2,12 +2,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
     <VersionPrefix>0.1.1</VersionPrefix>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <NugetPackageFolder Condition="$(NugetPackageFolder) == ''">$(USERPROFILE)\.nuget\packages</NugetPackageFolder>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="TarballTask.cs" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012" />

--- a/Packaging.Targets/TarballTask.cs
+++ b/Packaging.Targets/TarballTask.cs
@@ -3,6 +3,7 @@ using ICSharpCode.SharpZipLib.Tar;
 using ICSharpCode.SharpZipLib.Zip;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System;
 using System.Diagnostics;
 using System.IO;
 
@@ -17,19 +18,8 @@ namespace Packaging.Targets
             set;
         }
 
+        [Required]
         public string TarballPath
-        {
-            get;
-            set;
-        }
-
-        public string TargetRuntime
-        {
-            get;
-            set;
-        }
-
-        public string TargetFramework
         {
             get;
             set;
@@ -39,41 +29,10 @@ namespace Packaging.Targets
         {
             this.Log.LogMessage(MessageImportance.Normal, "Creating tarball '{0}' from folder '{1}'", this.TarballPath, this.PublishDir);
 
-            CreateWindowsTarball();
+            CreateLinuxTarball();
 
             this.Log.LogMessage(MessageImportance.Normal, "Created tarball '{0}' from folder '{1}'", this.TarballPath, this.PublishDir);
             return true;
-        }
-
-        private void CreateWindowsTarball()
-        {
-            using (var stream = File.Create(this.TarballPath))
-            using (var zipFile = ZipFile.Create(stream))
-            {
-                AddDirectory(zipFile, this.PublishDir, string.Empty);
-            }
-        }
-
-        private void AddDirectory(ZipFile zipFile, string directory, string directoryEntryName)
-        {
-            if (directoryEntryName != string.Empty)
-            {
-                zipFile.BeginUpdate();
-                zipFile.AddDirectory(directoryEntryName);
-                zipFile.CommitUpdate();
-            }
-
-            foreach (var file in Directory.GetFiles(directory))
-            {
-                zipFile.BeginUpdate();
-                zipFile.Add(file, Path.Combine(directoryEntryName, Path.GetFileName(file)));
-                zipFile.CommitUpdate();
-            }
-
-            foreach(var child in Directory.GetDirectories(directory))
-            {
-                AddDirectory(zipFile, child, Path.Combine(directoryEntryName, Path.GetFileName(child)));
-            }
         }
 
         private void CreateLinuxTarball()
@@ -82,7 +41,9 @@ namespace Packaging.Targets
             using (var gzipStream = new GZipOutputStream(stream))
             using (var archive = TarArchive.CreateOutputTarArchive(gzipStream))
             {
+                archive.RootPath = this.PublishDir.Replace("\\", "/");
                 var entry = TarEntry.CreateEntryFromFile(this.PublishDir);
+
                 archive.WriteEntry(entry, true);
             }
         }

--- a/Packaging.Targets/ZipTask.cs
+++ b/Packaging.Targets/ZipTask.cs
@@ -1,0 +1,68 @@
+﻿using ICSharpCode.SharpZipLib.Zip;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Packaging.Targets
+{
+    public class ZipTask : Task
+    {
+        [Required]
+        public string PublishDir
+        {
+            get;
+            set;
+        }
+
+        [Required]
+        public string ZipPath
+        {
+            get;
+            set;
+        }
+
+        public override bool Execute()
+        {
+            this.Log.LogMessage(MessageImportance.Normal, "Creating zip archive '{0}' from folder '{1}'", this.ZipPath, this.PublishDir);
+
+            CreateWindowsTarball();
+
+            this.Log.LogMessage(MessageImportance.Normal, "Created zip archive '{0}' from folder '{1}'", this.ZipPath, this.PublishDir);
+            return true;
+        }
+
+        private void CreateWindowsTarball()
+        {
+            using (var stream = File.Create(this.ZipPath))
+            using (var zipFile = ZipFile.Create(stream))
+            {
+                AddDirectory(zipFile, this.PublishDir, string.Empty);
+            }
+        }
+
+        private void AddDirectory(ZipFile zipFile, string directory, string directoryEntryName)
+        {
+            if (directoryEntryName != string.Empty)
+            {
+                zipFile.BeginUpdate();
+                zipFile.AddDirectory(directoryEntryName);
+                zipFile.CommitUpdate();
+            }
+
+            foreach (var file in Directory.GetFiles(directory))
+            {
+                zipFile.BeginUpdate();
+                zipFile.Add(file, Path.Combine(directoryEntryName, Path.GetFileName(file)));
+                zipFile.CommitUpdate();
+            }
+
+            foreach (var child in Directory.GetDirectories(directory))
+            {
+                AddDirectory(zipFile, child, Path.Combine(directoryEntryName, Path.GetFileName(child)));
+            }
+        }
+    }
+}

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -1,15 +1,23 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="Packaging.Targets.TarballTask" AssemblyFile="$(MSBuildThisFileDirectory)..\lib\netstandard1.4\Packaging.Targets.dll" />
-
-  <PropertyGroup>
-    <TarballPath>$(TargetDir)$(TargetName).zip</TarballPath>
-  </PropertyGroup>
+  <UsingTask TaskName="Packaging.Targets.ZipTask" AssemblyFile="$(MSBuildThisFileDirectory)..\lib\netstandard1.4\Packaging.Targets.dll" />
 
   <Target Name="CreateTarball" DependsOnTargets="Publish">
+    <PropertyGroup>
+      <TarballPath>$(TargetDir)$(TargetName).$(AssemblyFileVersion)-$(RuntimeIdentifier).tar.gz</TarballPath>
+    </PropertyGroup>
+
     <TarballTask PublishDir="$(PublishDir)"
-             TarballPath="$(TarballPath)"
-             TargetRuntime="$(TargetRuntime)"
-             TargetFramework="$(TargetFramework)"/>
+             TarballPath="$(TarballPath)"/>
+  </Target>
+
+  <Target Name="CreateZip" DependsOnTargets="Publish">
+    <PropertyGroup>
+      <ZipPath>$(TargetDir)$(TargetName).$(AssemblyFileVersion)-$(RuntimeIdentifier).zip</ZipPath>
+    </PropertyGroup>
+
+    <ZipTask PublishDir="$(PublishDir)"
+             ZipPath="$(ZipPath)"/>
   </Target>
 
   <!-- Support for building Windows Installer (.msi) packages -->

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,16 @@
+image: Visual Studio 2017
+
 version: '0.1.{build}'
 
 before_build:
-  - choco install -y wget
-  - wget https://dotnetcli.blob.core.windows.net/dotnet/Sdk/rel-1.0.0/dotnet-dev-win-x64.latest.exe -O dotnet-dev-win-x64.latest.exe -nv
-  - dotnet-dev-win-x64.latest.exe /install /quiet /log dotnet_install.txt
-  - ps: Push-AppVeyorArtifact dotnet_install.txt
-  - dotnet --version
-  - dotnet restore dotnet-tarball\dotnet-tarball.csproj
-  - dotnet restore Packaging.Targets\Packaging.Targets.csproj
-
+  - dotnet restore dotnet-packaging.sln
+  
 build_script:
-  - dotnet build dotnet-tarball\dotnet-tarball.csproj -c Release
-  - dotnet pack dotnet-tarball\dotnet-tarball.csproj -c Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
-  - dotnet build Packaging.Targets\Packaging.Targets.csproj -c Release
-  - dotnet pack Packaging.Targets\Packaging.Targets.csproj -c Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
+  - dotnet pack dotnet-packaging.sln -c Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
 
 on_success:
   - ps: Push-AppVeyorArtifact dotnet-tarball\bin\Release\dotnet-tarball.0.1.1-r$($env:APPVEYOR_BUILD_NUMBER).nupkg
+  - ps: Push-AppVeyorArtifact dotnet-zip\bin\Release\dotnet-zip.0.1.1-r$($env:APPVEYOR_BUILD_NUMBER).nupkg
   - ps: Push-AppVeyorArtifact Packaging.Targets\bin\Release\Packaging.Targets.0.1.1-r$($env:APPVEYOR_BUILD_NUMBER).nupkg
 
 nuget:

--- a/demo/NuGet.config
+++ b/demo/NuGet.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <add key="localFeed" value="../Packaging.Targets/bin/Debug" />
     <add key="appveyor" value="https://ci.appveyor.com/nuget/dotnet-packaging-s5cn128xv4ir" />
   </packageSources>
 </configuration>

--- a/demo/NuGet.config
+++ b/demo/NuGet.config
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="localFeed" value="../Packaging.Targets/bin/Debug" />
+    <add key="targetsFeed" value="../Packaging.Targets/bin/Debug" />
+    <add key="zipFeed" value="../dotnet-zip/bin/Debug" />
+    <add key="tarballFeed" value="../dotnet-tarball/bin/Debug" />
     <add key="appveyor" value="https://ci.appveyor.com/nuget/dotnet-packaging-s5cn128xv4ir" />
   </packageSources>
 </configuration>

--- a/demo/demo.csproj
+++ b/demo/demo.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.30" PrivateAssets="all"/>
     <PackageReference Include="Packaging.Targets" Version="0.1.1-*"/>
     <DotNetCliToolReference Include="dotnet-tarball" Version="0.1.1-*"/>
+    <DotNetCliToolReference Include="dotnet-zip" Version="0.1.1-*"/>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.0.0" />

--- a/demo/demo.csproj
+++ b/demo/demo.csproj
@@ -2,12 +2,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <PropertyGroup>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.30" PrivateAssets="all"/>
     <PackageReference Include="Packaging.Targets" Version="0.1.1-*"/>
     <DotNetCliToolReference Include="dotnet-tarball" Version="0.1.1-*"/>
   </ItemGroup>

--- a/demo/demo.csproj
+++ b/demo/demo.csproj
@@ -8,15 +8,10 @@
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Packaging.Targets" Version="0.1.1-*">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <DotNetCliToolReference Include="dotnet-tarball">
-      <Version>0.1.1-*</Version>
-    </DotNetCliToolReference>
+    <PackageReference Include="Packaging.Targets" Version="0.1.1-*"/>
+    <DotNetCliToolReference Include="dotnet-tarball" Version="0.1.1-*"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Tools" Version="1.0.0-preview2-final" />

--- a/demo/version.json
+++ b/demo/version.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0", // required
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$",
+    "^refs/tags/v\\d\\.\\d"
+  ]
+}

--- a/dotnet-packaging.sln
+++ b/dotnet-packaging.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-tarball", "dotnet-tarball\dotnet-tarball.csproj", "{7CC0E2CC-8D01-41A2-A8A6-951161D7E413}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Packaging.Targets", "Packaging.Targets\Packaging.Targets.csproj", "{FBB98D7F-35FD-463E-B3B3-5B67ECE22907}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-zip", "dotnet-zip\dotnet-zip.csproj", "{045283FC-CBB5-42A6-AD34-D8951D811DC0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7CC0E2CC-8D01-41A2-A8A6-951161D7E413}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7CC0E2CC-8D01-41A2-A8A6-951161D7E413}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7CC0E2CC-8D01-41A2-A8A6-951161D7E413}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7CC0E2CC-8D01-41A2-A8A6-951161D7E413}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FBB98D7F-35FD-463E-B3B3-5B67ECE22907}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBB98D7F-35FD-463E-B3B3-5B67ECE22907}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBB98D7F-35FD-463E-B3B3-5B67ECE22907}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBB98D7F-35FD-463E-B3B3-5B67ECE22907}.Release|Any CPU.Build.0 = Release|Any CPU
+		{045283FC-CBB5-42A6-AD34-D8951D811DC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{045283FC-CBB5-42A6-AD34-D8951D811DC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{045283FC-CBB5-42A6-AD34-D8951D811DC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{045283FC-CBB5-42A6-AD34-D8951D811DC0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/dotnet-tarball/dotnet-tarball.csproj
+++ b/dotnet-tarball/dotnet-tarball.csproj
@@ -3,6 +3,20 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <VersionPrefix>0.1.1</VersionPrefix>
+    <Authors>Frederik Carlier</Authors>
+    <Company>Quamotion</Company>
+    <Copyright>Copyright (c) Frederik Carlier and Contributors</Copyright>
+    <PackageLicenseUrl>https://github.com/qmfrederik/dotnet-packaging/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/qmfrederik/dotnet-packaging/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/qmfrederik/dotnet-packaging/</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>dotnet cli packaging tarball tar.gz archive</PackageTags>
+    <Description>Create tarballs (.tar.gz files) of your .NET Core projects straight from the command line.
+
+Once you've installed this package as a .NET CLI tool, run dotnet tar to generate a .tar.gz file which contains the publish output of your .NET Project.
+
+See https://github.com/qmfrederik/dotnet-packaging/ for more information on how to use dotnet tarball.</Description>
+    <Product>Packaging Tools for .NET CLI</Product>
   </PropertyGroup>
   <ItemGroup>
     <BuiltProjectOutputGroupOutput Include="$(ProjectRuntimeConfigFilePath)">

--- a/dotnet-zip/Program.cs
+++ b/dotnet-zip/Program.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var msbArguments = $"msbuild /t:CreateZip";
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = msbArguments
+        };
+
+        var process = new Process
+        {
+            StartInfo = psi,
+
+        };
+
+        process.Start();
+        process.WaitForExit();
+    }
+}

--- a/dotnet-zip/dotnet-zip.csproj
+++ b/dotnet-zip/dotnet-zip.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <VersionPrefix>0.1.1</VersionPrefix>
+  </PropertyGroup>
+  <ItemGroup>
+    <BuiltProjectOutputGroupOutput Include="$(ProjectRuntimeConfigFilePath)">
+      <FinalOutputPath>$(ProjectRuntimeConfigFilePath)</FinalOutputPath>
+    </BuiltProjectOutputGroupOutput>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Program.cs" />
+  </ItemGroup>
+</Project>

--- a/dotnet-zip/dotnet-zip.csproj
+++ b/dotnet-zip/dotnet-zip.csproj
@@ -3,6 +3,20 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <VersionPrefix>0.1.1</VersionPrefix>
+    <Authors>Frederik Carlier</Authors>
+    <Company>Quamotion</Company>
+    <Description>Create .zip files of your .NET Core projects straight from the command line.
+
+Once you've installed this package as a .NET CLI tool, run dotnet zip to generate a .zip file which contains the publish output of your .NET Project.
+
+See https://github.com/qmfrederik/dotnet-packaging/ for more information on how to use dotnet tarball.</Description>
+    <Copyright>Copyright (c) Frederik Carlier and Contributors</Copyright>
+    <PackageLicenseUrl>https://github.com/qmfrederik/dotnet-packaging/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/qmfrederik/dotnet-packaging/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/qmfrederik/dotnet-packaging/</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>dotnet cli packaging zip archive</PackageTags>
+    <Product>Packaging Tools for .NET CLI</Product>
   </PropertyGroup>
   <ItemGroup>
     <BuiltProjectOutputGroupOutput Include="$(ProjectRuntimeConfigFilePath)">


### PR DESCRIPTION
This PR adds the first 'final' versions of the dotnet zip and dotnet tarball commands. If you have a .NET project that targets multiple runtimes, you now get output like `{projectname}.{version}-{runtime}.zip|tar.gz`.

Also updates the projects to match the RTM version of the .NET Core tooling, and adds a solution file.