### PR TITLE
RPM: Support additional files, user creation, SystemD services, dependencies

### DIFF
--- a/Packaging.Targets.Tests/Rpm/DotnetFileAnalyzer.cs
+++ b/Packaging.Targets.Tests/Rpm/DotnetFileAnalyzer.cs
@@ -1,53 +1,50 @@
-﻿using Packaging.Targets.Rpm;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using Packaging.Targets.IO;
+﻿using Packaging.Targets.IO;
+using Packaging.Targets.Rpm;
 
 namespace Packaging.Targets.Tests.Rpm
 {
     internal class DotnetFileAnalyzer : FileAnalyzer
     {
-        public override string DetermineClass(string filename, CpioHeader fileHeader, byte[] header)
+        public override string DetermineClass(ArchiveEntry entry)
         {
-            if (filename.EndsWith(".map"))
+            if (entry.TargetPath.EndsWith(".map"))
             {
                 return "ASCII text, with very long lines, with no line terminators";
             }
-            else if (filename.EndsWith(".min.css"))
+            else if (entry.TargetPath.EndsWith(".min.css"))
             {
                 return "ASCII text, with very long lines, with CRLF line terminators";
             }
-            else if (filename.EndsWith("additional-methods.min.js"))
+            else if (entry.TargetPath.EndsWith("additional-methods.min.js"))
             {
                 return "UTF-8 Unicode text, with very long lines, with CRLF line terminators";
             }
-            else if (filename.EndsWith("jquery.validate.js"))
+            else if (entry.TargetPath.EndsWith("jquery.validate.js"))
             {
                 return "UTF-8 Unicode text, with very long lines, with CRLF line terminators";
             }
-            else if (filename.EndsWith("jquery.validate.min.js"))
+            else if (entry.TargetPath.EndsWith("jquery.validate.min.js"))
             {
                 return "UTF-8 Unicode text, with very long lines, with CRLF line terminators";
             }
-            else if(filename.EndsWith("jquery/LICENSE.txt"))
+            else if(entry.TargetPath.EndsWith("jquery/LICENSE.txt"))
             {
                 return "C source, ASCII text, with CRLF line terminators";
             }
-            else if (filename.EndsWith(".min.js"))
+            else if (entry.TargetPath.EndsWith(".min.js"))
             {
                 return "ASCII text, with very long lines, with CRLF line terminators";
             }
-            else if (filename.EndsWith("bootstrap.css"))
+            else if (entry.TargetPath.EndsWith("bootstrap.css"))
             {
                 return "C++ source, ASCII text, with very long lines, with CRLF line terminators";
             }
-            else if (filename.EndsWith("additional-methods.js"))
+            else if (entry.TargetPath.EndsWith("additional-methods.js"))
             {
                 return "UTF-8 Unicode text, with very long lines, with CRLF line terminators";
             }
 
-            var @class = base.DetermineClass(filename, fileHeader, header);
+            var @class = base.DetermineClass(entry);
 
             if (@class == "ASCII text")
             {
@@ -61,7 +58,7 @@ namespace Packaging.Targets.Tests.Rpm
             return @class;
         }
 
-        public override RpmFileFlags DetermineFlags(string filename, CpioHeader fileHeader, byte[] header)
+        public override RpmFileFlags DetermineFlags(ArchiveEntry entry)
         {
             return RpmFileFlags.None;
         }

--- a/Packaging.Targets.Tests/Rpm/PlistFileAnalyzer.cs
+++ b/Packaging.Targets.Tests/Rpm/PlistFileAnalyzer.cs
@@ -1,8 +1,5 @@
 ﻿using Packaging.Targets.IO;
 using Packaging.Targets.Rpm;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Collections.ObjectModel;
 
 namespace Packaging.Targets.Tests.Rpm
@@ -14,9 +11,9 @@ namespace Packaging.Targets.Tests.Rpm
     internal class PlistFileAnalyzer : FileAnalyzer
     {
         /// <inheritdoc/>
-        public override Collection<PackageDependency> DetermineProvides(string filename, CpioHeader fileHeader, byte[] header)
+        public override Collection<PackageDependency> DetermineProvides(ArchiveEntry entry)
         {
-            switch (filename)
+            switch (entry.TargetPath)
             {
                 case "/usr/bin/plistutil":
                     return new Collection<PackageDependency>()
@@ -34,13 +31,13 @@ namespace Packaging.Targets.Tests.Rpm
                     };
             }
 
-            return base.DetermineProvides(filename, fileHeader, header);
+            return base.DetermineProvides(entry);
         }
 
         /// <inheritdoc/>
-        public override Collection<PackageDependency> DetermineRequires(string filename, CpioHeader fileHeader, byte[] header)
+        public override Collection<PackageDependency> DetermineRequires(ArchiveEntry entry)
         {
-            switch (filename)
+            switch (entry.TargetPath)
             {
                 case "/usr/bin/plistutil":
                     return new Collection<PackageDependency>()
@@ -81,25 +78,25 @@ namespace Packaging.Targets.Tests.Rpm
                     };
             }
 
-            return base.DetermineRequires(filename, fileHeader, header);
+            return base.DetermineRequires(entry);
         }
 
         /// <inheritdoc/>
-        public override RpmFileColor DetermineColor(string filename, CpioHeader fileHeader, byte[] header)
+        public override RpmFileColor DetermineColor(ArchiveEntry entry)
         {
-            switch (filename)
+            switch (entry.TargetPath)
             {
                 case "/usr/share/doc/libplist-2.0.1.151/AUTHORS":
                     return RpmFileColor.RPMFC_BLACK;
             }
 
-            return base.DetermineColor(filename, fileHeader, header);
+            return base.DetermineColor(entry);
         }
 
         /// <inheritdoc/>
-        public override string DetermineClass(string filename, CpioHeader fileHeader, byte[] header)
+        public override string DetermineClass(ArchiveEntry entry)
         {
-            switch (filename)
+            switch (entry.TargetPath)
             {
                 case "/usr/bin/plistutil":
                     return "ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked (uses shared libs), for GNU/Linux 2.6.32, BuildID[sha1]=44864a4aec49ec94f3dc1486068ff0d308e3ae37, stripped";
@@ -117,7 +114,7 @@ namespace Packaging.Targets.Tests.Rpm
                     return "ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=cc5c79145ee69889a9fe95abaa70cf91b0d64d50, stripped";
             }
 
-            return base.DetermineClass(filename, fileHeader, header);
+            return base.DetermineClass(entry);
         }
     }
 }

--- a/Packaging.Targets.Tests/Rpm/RpmMetadataTests.cs
+++ b/Packaging.Targets.Tests/Rpm/RpmMetadataTests.cs
@@ -130,7 +130,7 @@ namespace Packaging.Targets.Tests.Rpm
                     creator.AddLdDependencies(metadata);
 
                     metadata.Files = files;
-                    creator.AddRpmDependencies(metadata);
+                    creator.AddRpmDependencies(metadata, null);
 
                     this.AssertTagEqual(IndexTag.RPMTAG_FILESIZES, originalPackage, package);
                     this.AssertTagEqual(IndexTag.RPMTAG_FILEMODES, originalPackage, package);
@@ -201,7 +201,7 @@ namespace Packaging.Targets.Tests.Rpm
                     creator.AddLdDependencies(metadata);
 
                     metadata.Files = files;
-                    creator.AddRpmDependencies(metadata);
+                    creator.AddRpmDependencies(metadata, null);
 
                     PlistMetadata.ApplyDefaultMetadata(metadata);
 

--- a/Packaging.Targets.Tests/Rpm/RpmMetadataTests.cs
+++ b/Packaging.Targets.Tests/Rpm/RpmMetadataTests.cs
@@ -115,8 +115,10 @@ namespace Packaging.Targets.Tests.Rpm
                 using (var payloadStream = RpmPayloadReader.GetDecompressedPayloadStream(originalPackage))
                 using (var cpio = new CpioFile(payloadStream, false))
                 {
+                    ArchiveBuilder builder = new ArchiveBuilder(new PlistFileAnalyzer());
                     RpmPackageCreator creator = new RpmPackageCreator(new PlistFileAnalyzer());
-                    var files = creator.CreateFiles(cpio);
+                    var entries = builder.FromCpio(cpio);
+                    var files = creator.CreateFiles(entries);
 
                     var metadata = new PublicRpmMetadata(package);
                     metadata.Name = "libplist";
@@ -182,8 +184,10 @@ namespace Packaging.Targets.Tests.Rpm
                 using (var payloadStream = RpmPayloadReader.GetDecompressedPayloadStream(originalPackage))
                 using (var cpio = new CpioFile(payloadStream, false))
                 {
+                    ArchiveBuilder builder = new ArchiveBuilder(new PlistFileAnalyzer());
                     RpmPackageCreator creator = new RpmPackageCreator(new PlistFileAnalyzer());
-                    var files = creator.CreateFiles(cpio);
+                    var entries = builder.FromCpio(cpio);
+                    var files = creator.CreateFiles(entries);
 
                     // Core routine to populate files and dependencies
                     RpmPackage package = new RpmPackage();

--- a/Packaging.Targets.Tests/Rpm/RpmPackageCreatorTests.cs
+++ b/Packaging.Targets.Tests/Rpm/RpmPackageCreatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Packaging.Targets.IO;
 using Packaging.Targets.Rpm;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
@@ -245,7 +246,7 @@ namespace Packaging.Targets.Tests.Rpm
             using (var targetStream = File.Open(@"RpmPackageCreatorTests_CreateTest.rpm", FileMode.Create, FileAccess.ReadWrite, FileShare.None))
             {
                 var originalPackage = RpmPackageReader.Read(stream);
-                Collection<ArchiveEntry> archive = null;
+                List<ArchiveEntry> archive = null;
 
                 using (var decompressedPayloadStream = RpmPayloadReader.GetDecompressedPayloadStream(originalPackage))
                 using (CpioFile cpio = new CpioFile(decompressedPayloadStream, leaveOpen: false))

--- a/Packaging.Targets.Tests/Rpm/RpmPackageCreatorTests.cs
+++ b/Packaging.Targets.Tests/Rpm/RpmPackageCreatorTests.cs
@@ -112,7 +112,7 @@ namespace Packaging.Targets.Tests.Rpm
                     creator.AddLdDependencies(metadata);
 
                     metadata.Files = files;
-                    creator.AddRpmDependencies(metadata);
+                    creator.AddRpmDependencies(metadata, null);
 
                     PlistMetadata.ApplyDefaultMetadata(metadata);
 
@@ -166,7 +166,7 @@ namespace Packaging.Targets.Tests.Rpm
                 creator.AddLdDependencies(metadata);
 
                 metadata.Files = files;
-                creator.AddRpmDependencies(metadata);
+                creator.AddRpmDependencies(metadata, null);
 
                 PlistMetadata.ApplyDefaultMetadata(metadata);
 
@@ -269,6 +269,9 @@ namespace Packaging.Targets.Tests.Rpm
                         "2.0.1.151",
                         "x86_64",
                         "1.1",
+                        false,
+                        false,
+                        null,
                         (metadata) => PlistMetadata.ApplyDefaultMetadata(metadata),
                         privateKey,
                         targetStream);

--- a/Packaging.Targets/ArchiveBuilder.cs
+++ b/Packaging.Targets/ArchiveBuilder.cs
@@ -1,0 +1,296 @@
+﻿using Packaging.Targets.IO;
+using Packaging.Targets.Rpm;
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Packaging.Targets
+{
+    /// <summary>
+    /// Creates a list of <see cref="ArchiveEntry"/> objects based on the publish directory of a .NET Core application.
+    /// </summary>
+    internal class ArchiveBuilder
+    {
+        private IFileAnalyzer fileAnayzer;
+        private uint inode = 0;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArchiveBuilder"/> class.
+        /// </summary>
+        public ArchiveBuilder()
+        {
+            fileAnayzer = new FileAnalyzer();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArchiveBuilder"/> class.
+        /// </summary>
+        /// <param name="analyzer">
+        /// A <see cref="IFileAnalyzer"/> which can extract item metadata.
+        /// </param>
+        public ArchiveBuilder(IFileAnalyzer analyzer)
+        {
+            if (analyzer == null)
+            {
+                throw new ArgumentNullException(nameof(analyzer));
+            }
+
+            this.fileAnayzer = analyzer;
+        }
+
+        /// <summary>
+        /// Extracts the <see cref="ArchiveEntry"/> objects from a CPIO file.
+        /// </summary>
+        /// <param name="file">
+        /// The CPIO file from which to extract the entries.
+        /// </param>
+        /// <returns>
+        /// A list of <see cref="ArchiveEntry"/> objects representing the data in the CPIO file.
+        /// </returns>
+        public Collection<ArchiveEntry> FromCpio(CpioFile file)
+        {
+            Collection<ArchiveEntry> value = new Collection<ArchiveEntry>();
+            byte[] buffer = new byte[1024];
+            byte[] fileHeader = null;
+
+            while (file.Read())
+            {
+                fileHeader = null;
+
+                ArchiveEntry entry = new ArchiveEntry()
+                {
+                    FileSize = file.EntryHeader.FileSize,
+                    Group = "root",
+                    Owner = "root",
+                    Inode = file.EntryHeader.Ino,
+                    Mode = file.EntryHeader.Mode,
+                    Modified = file.EntryHeader.Mtime,
+                    TargetPath = file.EntryName,
+                    Type = ArchiveEntryType.None,
+                    LinkTo = string.Empty,
+                    Sha256 = Array.Empty<byte>(),
+                    SourceFilename = null,
+                    IsAscii = true
+                };
+
+                if (entry.Mode.HasFlag(LinuxFileMode.S_IFREG) && !entry.Mode.HasFlag(LinuxFileMode.S_IFLNK))
+                {
+                    using (var fileStream = file.Open())
+                    using (var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256))
+                    {
+                        int read;
+
+                        while (true)
+                        {
+                            read = fileStream.Read(buffer, 0, buffer.Length);
+
+                            if (fileHeader == null)
+                            {
+                                fileHeader = new byte[read];
+                                Buffer.BlockCopy(buffer, 0, fileHeader, 0, read);
+                            }
+
+                            hasher.AppendData(buffer, 0, read);
+                            entry.IsAscii = entry.IsAscii && fileHeader.All(c => c < 128);
+
+                            if (read < buffer.Length)
+                            {
+                                break;
+                            }
+                        }
+
+                        entry.Sha256 = hasher.GetHashAndReset();
+                    }
+
+                    entry.Type = GetArchiveEntryType(fileHeader);
+                }
+                else if (entry.Mode.HasFlag(LinuxFileMode.S_IFLNK))
+                {
+                    using (var fileStrema = file.Open())
+                    using (var reader = new StreamReader(fileStrema, Encoding.UTF8))
+                    {
+                        entry.LinkTo = reader.ReadToEnd();
+                    }
+                }
+                else
+                {
+                    file.Skip();
+                }
+
+                if (entry.Mode.HasFlag(LinuxFileMode.S_IFDIR))
+                {
+                    entry.FileSize = 0x1000;
+                }
+
+                if (entry.TargetPath.StartsWith("."))
+                {
+                    entry.TargetPath = entry.TargetPath.Substring(1);
+                }
+
+                value.Add(entry);
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Extracts the <see cref="ArchiveEntry"/> objects from a directory.
+        /// </summary>
+        /// <param name="file">
+        /// The directory from which to extract the entries.
+        /// </param>
+        /// <returns>
+        /// A list of <see cref="ArchiveEntry"/> objects representing the data in the directory.
+        /// </returns>
+        public Collection<ArchiveEntry> FromDirectory(string directory, string prefix)
+        {
+            Collection<ArchiveEntry> value = new Collection<ArchiveEntry>();
+            AddDirectory(directory, prefix, value);
+            return value;
+        }
+
+        protected void AddDirectory(string directory, string prefix, Collection<ArchiveEntry> value)
+        {
+            // Write out an entry for the current directory
+            // (actually, this is _not_ done)
+            ArchiveEntry directoryEntry = new ArchiveEntry()
+            {
+                FileSize = 0x00001000,
+                Sha256 = Array.Empty<byte>(),
+                Mode = LinuxFileMode.S_IXOTH | LinuxFileMode.S_IROTH | LinuxFileMode.S_IXGRP | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IXUSR | LinuxFileMode.S_IWUSR | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFDIR,
+                Modified = Directory.GetLastWriteTime(directory),
+                Group = "root",
+                Owner = "root",
+                Inode = this.inode++
+            };
+
+            // The other in which the files appear in the cpio archive is important; if this is not respected xzdio
+            // will report errors like:
+            // error: unpacking of archive failed on file ./usr/share/quamotion/mscorlib.dll: cpio: Archive file not in header
+            var entries = Directory.GetFileSystemEntries(directory).OrderBy(e => Directory.Exists(e) ? e + "/" : e, StringComparer.Ordinal).ToArray();
+
+            foreach (var entry in entries)
+            {
+                if (File.Exists(entry))
+                {
+                    AddFile(entry, prefix, value);
+                }
+                else
+                {
+                    AddDirectory(entry, prefix + "/" + Path.GetFileName(entry), value);
+                }
+            }
+        }
+
+        protected void AddFile(string entry, string prefix, Collection<ArchiveEntry> value)
+        {
+            var fileName = Path.GetFileName(entry);
+
+            byte[] fileHeader = null;
+            byte[] hash = null;
+            byte[] buffer = new byte[1024];
+            bool isAscii = true;
+
+            using (Stream fileStream = File.OpenRead(entry))
+            {
+                if (fileName.StartsWith(".") || fileStream.Length == 0)
+                {
+                    // Skip hidden and empty files - this would case rmplint errors.
+                    return;
+                }
+
+                using (var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256))
+                {
+                    int read;
+
+                    while (true)
+                    {
+                        read = fileStream.Read(buffer, 0, buffer.Length);
+
+                        if (fileHeader == null)
+                        {
+                            fileHeader = new byte[read];
+                            Buffer.BlockCopy(buffer, 0, fileHeader, 0, read);
+                        }
+
+                        hasher.AppendData(buffer, 0, read);
+                        isAscii = isAscii && buffer.All(c => c < 128);
+
+                        if (read < buffer.Length)
+                        {
+                            break;
+                        }
+                    }
+
+                    hash = hasher.GetHashAndReset();
+                }
+
+                // Only support ELF32 and ELF64 colors; otherwise default to BLACK.
+                ArchiveEntryType entryType = GetArchiveEntryType(fileHeader);
+
+                var mode = LinuxFileMode.S_IROTH | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFREG;
+
+                if (entryType == ArchiveEntryType.Executable32 || entryType == ArchiveEntryType.Executable64)
+                {
+                    mode |= LinuxFileMode.S_IXOTH | LinuxFileMode.S_IXGRP | LinuxFileMode.S_IWUSR | LinuxFileMode.S_IXUSR;
+                }
+
+                string name = prefix + "/" + fileName;
+                string linkTo = string.Empty;
+
+                if (mode.HasFlag(LinuxFileMode.S_IFLNK))
+                {
+                    // Find the link text
+                    int stringEnd = 0;
+
+                    while (stringEnd < fileHeader.Length - 1 && fileHeader[stringEnd] != 0)
+                    {
+                        stringEnd++;
+                    }
+
+                    linkTo = Encoding.UTF8.GetString(fileHeader, 0, stringEnd + 1);
+                    hash = new byte[] { };
+                }
+
+                ArchiveEntry archiveEntry = new ArchiveEntry()
+                {
+                    FileSize = (uint)fileStream.Length,
+                    Group = "root",
+                    Owner = "root",
+                    Modified = File.GetLastAccessTimeUtc(entry),
+                    SourceFilename = entry,
+                    TargetPath = name,
+                    Sha256 = hash,
+                    Type = entryType,
+                    LinkTo = linkTo,
+                    Inode = this.inode++,
+                    IsAscii = isAscii
+                };
+
+                value.Add(archiveEntry);
+            }
+        }
+
+        private ArchiveEntryType GetArchiveEntryType(byte[] fileHeader)
+        {
+            if (ElfFile.IsElfFile(fileHeader))
+            {
+                ElfHeader elfHeader = ElfFile.ReadHeader(fileHeader);
+
+                if (elfHeader.@class == ElfClass.Elf32)
+                {
+                    return ArchiveEntryType.Executable32;
+                }
+                else
+                {
+                    return ArchiveEntryType.Executable64;
+                }
+            }
+
+            return ArchiveEntryType.None;
+        }
+    }
+}

--- a/Packaging.Targets/ArchiveBuilder.cs
+++ b/Packaging.Targets/ArchiveBuilder.cs
@@ -158,7 +158,8 @@ namespace Packaging.Targets
                     Owner = folder.GetOwner(),
                     Inode = this.inode++,
                     TargetPath = path,
-                    LinkTo = string.Empty
+                    LinkTo = string.Empty,
+                    RemoveOnUninstall = folder.GetRemoveOnUninstall()
                 };
 
                 value.Add(directoryEntry);

--- a/Packaging.Targets/CopyToDirectoryValue.cs
+++ b/Packaging.Targets/CopyToDirectoryValue.cs
@@ -1,0 +1,23 @@
+﻿namespace Packaging.Targets
+{
+    /// <summary>
+    /// Determines whether a file is copied to its output directory or not.
+    /// </summary>
+    internal enum CopyToDirectoryValue
+    {
+        /// <summary>
+        /// The file is never copied.
+        /// </summary>
+        DoNotCopy,
+
+        /// <summary>
+        /// The file is alwasy copied.
+        /// </summary>
+        Always,
+
+        /// <summary>
+        /// The file is copied only if it is newer.
+        /// </summary>
+        PreserveNewest
+    }
+}

--- a/Packaging.Targets/IO/ArchiveEntry.cs
+++ b/Packaging.Targets/IO/ArchiveEntry.cs
@@ -1,0 +1,82 @@
+﻿using System;
+
+namespace Packaging.Targets.IO
+{
+    /// <summary>
+    /// Represents an entry in a Unix archive (usually a CPIO or tar archive).
+    /// </summary>
+    public class ArchiveEntry
+    {
+        /// <summary>
+        /// Gets or sets the full path of the file or directory on the target file system.
+        /// </summary>
+        public string TargetPath
+        { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the owner of the file or directory.
+        /// </summary>
+        public string Owner
+        { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the group of the file or directory.
+        /// </summary>
+        public string Group
+        { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file mode of the file.
+        /// </summary>
+        public LinuxFileMode Mode
+        { get; set; }
+
+        /// <summary>
+        /// Gets or sets the full path to the file on the source operating system.
+        /// </summary>
+        public string SourceFilename
+        { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total file size, in bytes.
+        /// </summary>
+        public uint FileSize
+        { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date at which the file was last modified.
+        /// </summary>
+        public DateTimeOffset Modified
+        { get; set; }
+
+        /// <summary>
+        /// Gets or sets the SHA256 of the file contents.
+        /// </summary>
+        public byte[] Sha256
+        { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file type (executable or not).
+        /// </summary>
+        public ArchiveEntryType Type
+        { get; set; }
+
+        /// <summary>
+        /// Gets or sets, if the file is a link, the link target.
+        /// </summary>
+        public string LinkTo
+        { get; set; }
+
+        /// <summary>
+        /// Gets or sets the inode number for the file.
+        /// </summary>
+        public uint Inode
+        { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the file only contains ASCII characters.
+        /// </summary>
+        public bool IsAscii
+        { get; set; }
+    }
+}

--- a/Packaging.Targets/IO/ArchiveEntry.cs
+++ b/Packaging.Targets/IO/ArchiveEntry.cs
@@ -78,5 +78,31 @@ namespace Packaging.Targets.IO
         /// </summary>
         public bool IsAscii
         { get; set; }
+
+        /// <summary>
+        /// Gets the file name, including a final slash if the file is a directory.
+        /// Used when sorting entries to make sure a directory entry immediately preceeds
+        /// all of its children.
+        /// </summary>
+        public string TargetPathWithFinalSlash
+        {
+            get
+            {
+                if (this.Mode.HasFlag(LinuxFileMode.S_IFDIR) && !this.TargetPath.EndsWith("/"))
+                {
+                    return this.TargetPath + "/";
+                }
+                else
+                {
+                    return this.TargetPath;
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.TargetPath;
+        }
     }
 }

--- a/Packaging.Targets/IO/ArchiveEntry.cs
+++ b/Packaging.Targets/IO/ArchiveEntry.cs
@@ -78,6 +78,13 @@ namespace Packaging.Targets.IO
         /// </summary>
         public bool IsAscii
         { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether this entry (and any child entries) is forcefully
+        /// removed when the application is uninstalled.
+        /// </summary>
+        public bool RemoveOnUninstall
+        { get; set; }
 
         /// <summary>
         /// Gets the file name, including a final slash if the file is a directory.

--- a/Packaging.Targets/IO/ArchiveEntryType.cs
+++ b/Packaging.Targets/IO/ArchiveEntryType.cs
@@ -1,0 +1,23 @@
+﻿namespace Packaging.Targets.IO
+{
+    /// <summary>
+    /// Represents the type of entry in an archive.
+    /// </summary>
+    public enum ArchiveEntryType
+    {
+        /// <summary>
+        /// The file as no special type.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The file is a 32-bit executable.
+        /// </summary>
+        Executable32 = 1,
+
+        /// <summary>
+        /// The file is a 64-bit executable.
+        /// </summary>
+        Executable64 = 2
+    }
+}

--- a/Packaging.Targets/IO/CpioFileCreator.cs
+++ b/Packaging.Targets/IO/CpioFileCreator.cs
@@ -1,5 +1,6 @@
 ﻿using Packaging.Targets.Rpm;
-using System.Collections.ObjectModel;
+using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Packaging.Targets.IO
@@ -32,7 +33,7 @@ namespace Packaging.Targets.IO
         /// <param name="targetStream">
         /// The <see cref="Stream"/> which will hold the <see cref="CpioFile"/>.
         /// </param>
-        public void FromArchiveEntries(Collection<ArchiveEntry> archiveEntries, Stream targetStream)
+        public void FromArchiveEntries(List<ArchiveEntry> archiveEntries, Stream targetStream)
         {
             using (CpioFile cpioFile = new CpioFile(targetStream, leaveOpen: true))
             {
@@ -82,7 +83,13 @@ namespace Packaging.Targets.IO
                 NameSize = 0
             };
 
-            cpioFile.Write(directoryHeader, entry.TargetPath, null);
+            var targetPath = entry.TargetPath;
+            if (!targetPath.StartsWith("."))
+            {
+                targetPath = "." + targetPath;
+            }
+
+            cpioFile.Write(directoryHeader, targetPath, new MemoryStream(Array.Empty<byte>()));
         }
 
         /// <summary>
@@ -96,6 +103,13 @@ namespace Packaging.Targets.IO
         /// </param>
         public void AddFile(ArchiveEntry entry, CpioFile cpioFile)
         {
+            var targetPath = entry.TargetPath;
+
+            if (!targetPath.StartsWith("."))
+            {
+                targetPath = "." + targetPath;
+            }
+
             using (Stream fileStream = File.OpenRead(entry.SourceFilename))
             {
                 CpioHeader cpioHeader = new CpioHeader()
@@ -116,7 +130,7 @@ namespace Packaging.Targets.IO
                     Signature = "070701",
                 };
 
-                cpioFile.Write(cpioHeader, entry.TargetPath, fileStream);
+                cpioFile.Write(cpioHeader, targetPath, fileStream);
             }
         }
     }

--- a/Packaging.Targets/Rpm/DefaultOrder.cs
+++ b/Packaging.Targets/Rpm/DefaultOrder.cs
@@ -9,7 +9,9 @@ namespace Packaging.Targets.Rpm
     internal class DefaultOrder
     {
         /// <summary>
-        /// Gets the default order in which the tags are saved in the header section.
+        /// Gets the default order in which the tags are saved in the header section. The order depends on the integer value
+        /// of the tag, in ascending order. RPM is very finicky about this order - if you do not respect it, the RPM package
+        /// will almost certainly be rejected which messages such as "headerRead failed: hdr load: BAD".
         /// </summary>
         public static List<IndexTag> Header
         {
@@ -34,6 +36,10 @@ namespace Packaging.Targets.Rpm
                     IndexTag.RPMTAG_URL,
                     IndexTag.RPMTAG_OS,
                     IndexTag.RPMTAG_ARCH,
+                    IndexTag.RPMTAG_PREIN,
+                    IndexTag.RPMTAG_POSTIN,
+                    IndexTag.RPMTAG_PREUN,
+                    IndexTag.RPMTAG_POSTUN,
                     IndexTag.RPMTAG_FILESIZES,
                     IndexTag.RPMTAG_FILEMODES,
                     IndexTag.RPMTAG_FILERDEVS,
@@ -53,7 +59,9 @@ namespace Packaging.Targets.Rpm
                     IndexTag.RPMTAG_CHANGELOGTIME,
                     IndexTag.RPMTAG_CHANGELOGNAME,
                     IndexTag.RPMTAG_CHANGELOGTEXT,
+                    IndexTag.RPMTAG_PREINPROG,
                     IndexTag.RPMTAG_POSTINPROG,
+                    IndexTag.RPMTAG_PREUNPROG,
                     IndexTag.RPMTAG_POSTUNPROG,
                     IndexTag.RPMTAG_COOKIE,
                     IndexTag.RPMTAG_FILEDEVICES,

--- a/Packaging.Targets/Rpm/FileAnalyzer.cs
+++ b/Packaging.Targets/Rpm/FileAnalyzer.cs
@@ -1,5 +1,7 @@
 ﻿using Packaging.Targets.IO;
+using System;
 using System.Collections.ObjectModel;
+using System.IO;
 
 namespace Packaging.Targets.Rpm
 {
@@ -11,7 +13,7 @@ namespace Packaging.Targets.Rpm
     internal class FileAnalyzer : IFileAnalyzer
     {
         /// <inheritdoc/>
-        public virtual Collection<PackageDependency> DetermineRequires(string filename, CpioHeader fileHeader, byte[] header)
+        public virtual Collection<PackageDependency> DetermineRequires(ArchiveEntry entry)
         {
             // For now, report no dependencies at all. Could be enhanced if ELF parsing is available.
             var dependencies = new Collection<PackageDependency>();
@@ -20,7 +22,7 @@ namespace Packaging.Targets.Rpm
         }
 
         /// <inheritdoc/>
-        public virtual Collection<PackageDependency> DetermineProvides(string filename, CpioHeader fileHeader, byte[] header)
+        public virtual Collection<PackageDependency> DetermineProvides(ArchiveEntry entry)
         {
             // For now, report no provides at all. Could be enhanced if ELF parsing is available.
             var dependencies = new Collection<PackageDependency>();
@@ -29,21 +31,21 @@ namespace Packaging.Targets.Rpm
         }
 
         /// <inheritdoc/>
-        public virtual RpmFileFlags DetermineFlags(string filename, CpioHeader fileHeader, byte[] header)
+        public virtual RpmFileFlags DetermineFlags(ArchiveEntry entry)
         {
             // The only custom flags which are supported for now are the RPMFILE_DOC flags for non-executable
             // files.
-            if (fileHeader.Mode.HasFlag(LinuxFileMode.S_IFDIR))
+            if (entry.Mode.HasFlag(LinuxFileMode.S_IFDIR))
             {
                 return RpmFileFlags.None;
             }
-            else if (fileHeader.Mode.HasFlag(LinuxFileMode.S_IFLNK))
+            else if (entry.Mode.HasFlag(LinuxFileMode.S_IFLNK))
             {
                 return RpmFileFlags.None;
             }
-            else if (!fileHeader.Mode.HasFlag(LinuxFileMode.S_IXGRP)
-                    && !fileHeader.Mode.HasFlag(LinuxFileMode.S_IXOTH)
-                    && !fileHeader.Mode.HasFlag(LinuxFileMode.S_IXUSR))
+            else if (!entry.Mode.HasFlag(LinuxFileMode.S_IXGRP)
+                    && !entry.Mode.HasFlag(LinuxFileMode.S_IXOTH)
+                    && !entry.Mode.HasFlag(LinuxFileMode.S_IXUSR))
             {
                 return RpmFileFlags.RPMFILE_DOC;
             }
@@ -54,88 +56,75 @@ namespace Packaging.Targets.Rpm
         }
 
         /// <inheritdoc/>
-        public virtual RpmFileColor DetermineColor(string filename, CpioHeader fileHeader, byte[] header)
+        public virtual RpmFileColor DetermineColor(ArchiveEntry entry)
         {
-            // Only support ELF32 and ELF64 colors; otherwise default to BLACK.
-            if (ElfFile.IsElfFile(header))
+            // Only support ELF32 and ELF64 
+            switch (entry.Type)
             {
-                ElfHeader elfHeader = ElfFile.ReadHeader(header);
-
-                if (elfHeader.@class == ElfClass.Elf32)
-                {
+                case ArchiveEntryType.Executable32:
                     return RpmFileColor.RPMFC_ELF32;
-                }
-                else
-                {
+
+                case ArchiveEntryType.Executable64:
                     return RpmFileColor.RPMFC_ELF64;
-                }
-            }
-            else
-            {
-                return RpmFileColor.RPMFC_BLACK;
+
+                default:
+                    return RpmFileColor.RPMFC_BLACK;
             }
         }
 
         /// <inheritdoc/>
-        public virtual bool IsExecutable(byte[] header)
+        public virtual bool IsExecutable(ArchiveEntry entry)
         {
-            if (ElfFile.IsElfFile(header))
-            {
-                ElfHeader elfHeader = ElfFile.ReadHeader(header);
-                return elfHeader.type.HasFlag(ElfType.Executable);
-            }
-
-            return false;
+            throw new NotSupportedException();
         }
 
         /// <inheritdoc/>
-        public virtual string DetermineClass(string filename, CpioHeader fileHeader, byte[] header)
+        public virtual string DetermineClass(ArchiveEntry entry)
         {
             // Very simplistic implementation - non-executable files are considered to be tet files.
-            if (fileHeader.Mode.HasFlag(LinuxFileMode.S_IFDIR))
+            if (entry.Mode.HasFlag(LinuxFileMode.S_IFDIR))
             {
                 return "directory";
             }
 
-            if (fileHeader.Mode.HasFlag(LinuxFileMode.S_IFLNK))
+            if (entry.Mode.HasFlag(LinuxFileMode.S_IFLNK))
             {
                 return string.Empty;
             }
 
-            if (filename.EndsWith(".svg"))
+            if (entry.TargetPath.EndsWith(".svg"))
             {
                 return "SVG Scalable Vector Graphics image";
             }
-            else if (filename.EndsWith(".ttf"))
+            else if (entry.TargetPath.EndsWith(".ttf"))
             {
                 return "TrueType font data";
             }
-            else if (filename.EndsWith(".woff"))
+            else if (entry.TargetPath.EndsWith(".woff"))
             {
                 return string.Empty;
             }
-            else if (filename.EndsWith(".woff2"))
+            else if (entry.TargetPath.EndsWith(".woff2"))
             {
                 return string.Empty;
             }
-            else if (filename.EndsWith(".eot"))
+            else if (entry.TargetPath.EndsWith(".eot"))
             {
                 return string.Empty;
             }
 
-            if (!fileHeader.Mode.HasFlag(LinuxFileMode.S_IXGRP)
-                && !fileHeader.Mode.HasFlag(LinuxFileMode.S_IXOTH)
-                && !fileHeader.Mode.HasFlag(LinuxFileMode.S_IXUSR))
+            if (!entry.Mode.HasFlag(LinuxFileMode.S_IXGRP)
+                && !entry.Mode.HasFlag(LinuxFileMode.S_IXOTH)
+                && !entry.Mode.HasFlag(LinuxFileMode.S_IXUSR))
             {
-                for (int i = 0; i < header.Length; i++)
+                if (entry.IsAscii)
                 {
-                    if (header[i] > 127)
-                    {
-                        return "UTF-8 Unicode text";
-                    }
+                    return "ASCII text";
                 }
-
-                return "ASCII text";
+                else
+                {
+                    return "UTF-8 Unicode text";
+                }
             }
 
             return string.Empty;

--- a/Packaging.Targets/Rpm/IFileAnalyzer.cs
+++ b/Packaging.Targets/Rpm/IFileAnalyzer.cs
@@ -11,88 +11,58 @@ namespace Packaging.Targets.Rpm
         /// <summary>
         /// Gets the <see cref="RpmFileFlags"/> which apply to this file.
         /// </summary>
-        /// <param name="fileName">
-        /// The name of the file to analyze.
-        /// </param>
-        /// <param name="fileHeader">
-        /// The <see cref="CpioHeader"/> of the file to analyze.
-        /// </param>
-        /// <param name="header">
-        /// The first bytes of the file to analyze.
-        /// </param>
+        /// <param name="entry">
+        /// The entry to analyze.
         /// <returns>
         /// The <see cref="RpmFileFlags"/> for the file.
         /// </returns>
-        RpmFileFlags DetermineFlags(string fileName, CpioHeader fileHeader, byte[] header);
+        RpmFileFlags DetermineFlags(ArchiveEntry entry);
 
         /// <summary>
         /// Gets the dependencies for this file.
         /// </summary>
-        /// <param name="fileName">
-        /// The name of the file to analyze.
-        /// </param>
-        /// <param name="fileHeader">
-        /// The <see cref="CpioHeader"/> of the file to analyze.
-        /// </param>
-        /// <param name="header">
-        /// The first bytes of the file to analyze.
-        /// </param>
+        /// <param name="entry">
+        /// The entry to analyze.
+        /// <returns>
         /// <returns>
         /// The dependencies for the file.
         /// </returns>
-        Collection<PackageDependency> DetermineRequires(string fileName, CpioHeader fileHeader, byte[] header);
+        Collection<PackageDependency> DetermineRequires(ArchiveEntry entry);
 
         /// <summary>
         /// Gets the dependencies fulfilled by this file.
         /// </summary>
-        /// <param name="fileName">
-        /// The name of the file to analyze.
-        /// </param>
-        /// <param name="fileHeader">
-        /// The <see cref="CpioHeader"/> of the file to analyze.
-        /// </param>
-        /// <param name="header">
-        /// The first bytes of the file to analyze.
-        /// </param>
+        /// <param name="entry">
+        /// The entry to analyze.
+        /// <returns>
         /// <returns>
         /// The dependencies fulfilled by the file.
         /// </returns>
-        Collection<PackageDependency> DetermineProvides(string fileName, CpioHeader fileHeader, byte[] header);
+        Collection<PackageDependency> DetermineProvides(ArchiveEntry entry);
 
         /// <summary>
         /// Gets the <see cref="RpmFileColor"/> for this file.
         /// </summary>
-        /// <param name="fileName">
-        /// The name of the file to analyze.
-        /// </param>
-        /// <param name="fileHeader">
-        /// The <see cref="CpioHeader"/> of the file to analyze.
-        /// </param>
-        /// <param name="header">
-        /// The first bytes of the file to analyze.
+        /// <param name="entry">
+        /// The entry to analyze.
+        /// <returns>tes of the file to analyze.
         /// </param>
         /// <returns>
         /// The <see cref="RpmFileColor"/> for the file.
         /// </returns>
-        RpmFileColor DetermineColor(string fileName, CpioHeader fileHeader, byte[] header);
+        RpmFileColor DetermineColor(ArchiveEntry entry);
 
         /// <summary>
         /// Gets the class of this file.
         /// </summary>
-        /// <param name="fileName">
-        /// The name of the file to analyze.
-        /// </param>
-        /// <param name="fileHeader">
-        /// The <see cref="CpioHeader"/> of the file to analyze.
-        /// </param>
-        /// <param name="header">
-        /// The first bytes of the file to analyze.
-        /// </param>
+        /// <param name="entry">
+        /// The entry to analyze.
+        /// <returns>
         /// <returns>
         /// The class of this file.
         /// </returns>
-        string DetermineClass(string fileName, CpioHeader fileHeader, byte[] header);
+        string DetermineClass(ArchiveEntry entry);
 
-        bool IsExecutable(byte[] header);
+        bool IsExecutable(ArchiveEntry entry);
     }
 }

--- a/Packaging.Targets/Rpm/IndexTag.cs
+++ b/Packaging.Targets/Rpm/IndexTag.cs
@@ -117,12 +117,24 @@
         /// </summary>
         RPMTAG_ARCH = 1022,
 
+        /// <summary>
+        /// Scripts which run before installing the package.
+        /// </summary>
         RPMTAG_PREIN = 1023,
 
+        /// <summary>
+        /// Scripts which run after installing the package.
+        /// </summary>
         RPMTAG_POSTIN = 1024,
 
+        /// <summary>
+        /// Scripts which run before uninstalling the package.
+        /// </summary>
         RPMTAG_PREUN = 1025,
 
+        /// <summary>
+        /// Scripts which run after uninstalling the package.
+        /// </summary>
         RPMTAG_POSTUN = 1026,
 
         /// <summary>
@@ -296,12 +308,24 @@
 
         RPMTAG_PREREQ = 1084,
 
+        /// <summary>
+        /// The program which launches the pre-install script.
+        /// </summary>
         RPMTAG_PREINPROG = 1085,
 
+        /// <summary>
+        /// The program which launches the post-install script.
+        /// </summary>
         RPMTAG_POSTINPROG = 1086,
 
+        /// <summary>
+        /// The program which launches the pre-removal script.
+        /// </summary>
         RPMTAG_PREUNPROG = 1087,
 
+        /// <summary>
+        /// The program which launches the post-removal script.
+        /// </summary>
         RPMTAG_POSTUNPROG = 1088,
 
         RPMTAG_BUILDARCHS = 1089,

--- a/Packaging.Targets/Rpm/RpmMetadata.cs
+++ b/Packaging.Targets/Rpm/RpmMetadata.cs
@@ -235,12 +235,66 @@ namespace Packaging.Targets.Rpm
         }
 
         /// <summary>
+        /// Gets the scipt to run before installation of this package.
+        /// </summary>
+        public string PreIn
+        {
+            get { return this.GetString(IndexTag.RPMTAG_PREIN); }
+            set { this.SetString(IndexTag.RPMTAG_PREIN, value); }
+        }
+
+        /// <summary>
+        /// Gets the scipt to run after installation of this package.
+        /// </summary>
+        public string PostIn
+        {
+            get { return this.GetString(IndexTag.RPMTAG_POSTIN); }
+            set { this.SetString(IndexTag.RPMTAG_POSTIN, value); }
+        }
+
+        /// <summary>
+        /// Gets the scipt to run before removal of this package.
+        /// </summary>
+        public string PreUn
+        {
+            get { return this.GetString(IndexTag.RPMTAG_PREUN); }
+            set { this.SetString(IndexTag.RPMTAG_PREUN, value); }
+        }
+
+        /// <summary>
+        /// Gets the scipt to run after removal of this package.
+        /// </summary>
+        public string PostUn
+        {
+            get { return this.GetString(IndexTag.RPMTAG_POSTUN); }
+            set { this.SetString(IndexTag.RPMTAG_POSTUN, value); }
+        }
+
+        /// <summary>
+        /// Gets the name of the program to run before installation of this package.
+        /// </summary>
+        public string PreInProg
+        {
+            get { return this.GetString(IndexTag.RPMTAG_PREINPROG); }
+            set { this.SetString(IndexTag.RPMTAG_PREINPROG, value); }
+        }
+
+        /// <summary>
         /// Gets the name of the program to run after installation of this package.
         /// </summary>
         public string PostInProg
         {
             get { return this.GetString(IndexTag.RPMTAG_POSTINPROG); }
             set { this.SetString(IndexTag.RPMTAG_POSTINPROG, value); }
+        }
+
+        /// <summary>
+        /// Gets the name of the program to run before removal of this package.
+        /// </summary>
+        public string PreUnProg
+        {
+            get { return this.GetString(IndexTag.RPMTAG_PREUNPROG); }
+            set { this.SetString(IndexTag.RPMTAG_PREUNPROG, value); }
         }
 
         /// <summary>

--- a/Packaging.Targets/Rpm/RpmPackageCreator.cs
+++ b/Packaging.Targets/Rpm/RpmPackageCreator.cs
@@ -79,7 +79,7 @@ namespace Packaging.Targets.Rpm
         /// The <see cref="Stream"/> to which to write the package.
         /// </param>
         public void CreatePackage(
-            Collection<ArchiveEntry> archiveEntries,
+            List<ArchiveEntry> archiveEntries,
             Stream payloadStream,
             string name,
             string version,
@@ -234,15 +234,22 @@ namespace Packaging.Targets.Rpm
         /// <returns>
         /// A <see cref="Collection{RpmFile}"/> which contains all the metadata.
         /// </returns>
-        public Collection<RpmFile> CreateFiles(Collection<ArchiveEntry> archiveEntries)
+        public Collection<RpmFile> CreateFiles(List<ArchiveEntry> archiveEntries)
         {
             Collection<RpmFile> files = new Collection<RpmFile>();
 
-            foreach(var entry in archiveEntries)
+            foreach (var entry in archiveEntries)
             {
+                var size = entry.FileSize;
+
+                if (entry.Mode.HasFlag(LinuxFileMode.S_IFDIR))
+                {
+                    size = 0x1000;
+                }
+
                 RpmFile file = new RpmFile()
                 {
-                    Size = (int)entry.FileSize,
+                    Size = (int)size,
                     Mode = entry.Mode,
                     Rdev = 0,
                     ModifiedTime = entry.Modified,

--- a/Packaging.Targets/RpmTask.cs
+++ b/Packaging.Targets/RpmTask.cs
@@ -72,15 +72,20 @@ namespace Packaging.Targets
             using (var targetStream = File.Open(this.RpmPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
             using (var cpioStream = File.Open(this.CpioPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
             {
-                CpioFileCreator cpioCreator = new CpioFileCreator();
-                cpioCreator.FromDirectory(
+                ArchiveBuilder archiveBuilder = new ArchiveBuilder();
+                var archiveEntries = archiveBuilder.FromDirectory(
                     this.PublishDir,
-                    this.Prefix,
+                    this.Prefix);
+
+                CpioFileCreator cpioCreator = new CpioFileCreator();
+                cpioCreator.FromArchiveEntries(
+                    archiveEntries,
                     cpioStream);
                 cpioStream.Position = 0;
 
                 RpmPackageCreator rpmCreator = new RpmPackageCreator();
                 rpmCreator.CreatePackage(
+                    archiveEntries,
                     cpioStream,
                     this.PackageName,
                     this.Version,

--- a/Packaging.Targets/RpmTask.cs
+++ b/Packaging.Targets/RpmTask.cs
@@ -72,6 +72,26 @@ namespace Packaging.Targets
             set;
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to create a Linux
+        /// user and group when installing the package.
+        /// </summary>
+        public bool CreateUser
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to install
+        /// and launch as systemd service when installing the package.
+        /// </summary>
+        public bool InstallService
+        {
+            get;
+            set;
+        }
+
         public override bool Execute()
         {
             this.Log.LogMessage(MessageImportance.Normal, "Creating RPM package '{0}' from folder '{1}'", this.RpmPath, this.PublishDir);
@@ -109,6 +129,8 @@ namespace Packaging.Targets
                     this.Version,
                     "x86_64",
                     this.Release,
+                    this.CreateUser,
+                    this.InstallService,
                     null,
                     privateKey,
                     targetStream);

--- a/Packaging.Targets/RpmTask.cs
+++ b/Packaging.Targets/RpmTask.cs
@@ -66,7 +66,21 @@ namespace Packaging.Targets
             set;
         }
 
+        /// <summary>
+        /// Gets or sets a list of empty folders to create when
+        /// installing this package.
+        /// </summary>
         public ITaskItem[] LinuxFolders
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a list of RPM packages on which this RPM
+        /// package dpeends.
+        /// </summary>
+        public ITaskItem[] RpmDependencies
         {
             get;
             set;
@@ -121,6 +135,15 @@ namespace Packaging.Targets
                     cpioStream);
                 cpioStream.Position = 0;
 
+                // Prepare the list of dependencies
+                var dependencies =
+                    this.RpmDependencies.Select(
+                        d => new PackageDependency(
+                            d.ItemSpec,
+                            RpmSense.RPMSENSE_EQUAL | RpmSense.RPMSENSE_GREATER,
+                            d.GetVersion()))
+                        .ToArray();
+
                 RpmPackageCreator rpmCreator = new RpmPackageCreator();
                 rpmCreator.CreatePackage(
                     archiveEntries,
@@ -131,6 +154,7 @@ namespace Packaging.Targets
                     this.Release,
                     this.CreateUser,
                     this.InstallService,
+                    dependencies,
                     null,
                     privateKey,
                     targetStream);

--- a/Packaging.Targets/TaskItemExtensions.cs
+++ b/Packaging.Targets/TaskItemExtensions.cs
@@ -93,7 +93,6 @@ namespace Packaging.Targets
             return TryGetValue(item, "Owner", "root");
         }
 
-
         /// <summary>
         /// Gets the Linux group of the file.
         /// </summary>
@@ -106,6 +105,30 @@ namespace Packaging.Targets
         public static string GetGroup(this ITaskItem item)
         {
             return TryGetValue(item, "Group", "root");
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the item should be removed when the
+        /// program is removed.
+        /// </summary>
+        /// <param name="item">
+        /// The item to inspect.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the file should be removed; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
+        public static bool GetRemoveOnUninstall(this ITaskItem item)
+        {
+            var valueString = TryGetValue(item, "RemoveOnUninstall", "false");
+            bool value;
+
+            if (!bool.TryParse(valueString, out value))
+            {
+                return false;
+            }
+
+            return value;
         }
 
         private static string TryGetValue(ITaskItem item, string name, string @default = null)

--- a/Packaging.Targets/TaskItemExtensions.cs
+++ b/Packaging.Targets/TaskItemExtensions.cs
@@ -108,6 +108,20 @@ namespace Packaging.Targets
         }
 
         /// <summary>
+        /// Gets the version of the RPM dependency.
+        /// </summary>
+        /// <param name="item">
+        /// The task item which represents the RPM dependency.
+        /// </param>
+        /// <returns>
+        /// The version of the dependency.
+        /// </returns>
+        public static string GetVersion(this ITaskItem item)
+        {
+            return TryGetValue(item, "Version", null);
+        }
+
+        /// <summary>
         /// Gets a value indicating whether the item should be removed when the
         /// program is removed.
         /// </summary>

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -34,6 +34,7 @@
              PackageName="$(PackageName)"
              Content="@(Content)"
              LinuxFolders="@(LinuxFolder)"
+             RpmDependencies="@(RpmDependency)"
              CreateUser="$(CreateUser)"
              InstallService="$(InstallService)"/>
   </Target>

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -16,7 +16,7 @@
     <PropertyGroup>
       <RpmPath>$(PackagePath).rpm</RpmPath>
       <CpioPath>$(IntermediatePackagePath).cpio</CpioPath>
-      <Prefix>./usr/share/$(TargetName)</Prefix>
+      <Prefix>/usr/share/$(TargetName)</Prefix>
       <Release>0</Release>
       <PackageName>$(TargetName)</PackageName>
     </PropertyGroup>
@@ -29,7 +29,9 @@
              Prefix="$(Prefix)"
              Version="$(AssemblyFileVersion)"
              Release="$(Release)"
-             PackageName="$(PackageName)"/>
+             PackageName="$(PackageName)"
+             Content="@(Content)"
+             LinuxFolders="@(LinuxFolder)"/>
   </Target>
 
   <Target Name="CreateTarball" DependsOnTargets="CreatePackageProperties">

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -9,9 +9,11 @@
       <PackageName Condition="'$(PackageName)' == ''">$(PackagePrefix).$(AssemblyFileVersion).$(RuntimeIdentifier)</PackageName>
       <IntermediatePackagePath>$(IntermediateOutputPath)$(PackageName)</IntermediatePackagePath>
       <PackagePath>$(TargetDir)$(PackageName)</PackagePath>
+      <CreateUser Condition="'$(CreateUser)' == ''">false</CreateUser>
+      <InstallService Condition="'$(InstallService)' == ''">false</InstallService>
     </PropertyGroup>
   </Target>
-  
+
   <Target Name="CreateRpm" DependsOnTargets="CreatePackageProperties">
     <PropertyGroup>
       <RpmPath>$(PackagePath).rpm</RpmPath>
@@ -22,7 +24,7 @@
     </PropertyGroup>
 
     <Message Text="Creating $(RpmPath)" Importance="normal"/>
-    
+
     <RpmTask PublishDir="$(PublishDir)"
              RpmPath="$(RpmPath)"
              CpioPath="$(CpioPath)"
@@ -31,7 +33,9 @@
              Release="$(Release)"
              PackageName="$(PackageName)"
              Content="@(Content)"
-             LinuxFolders="@(LinuxFolder)"/>
+             LinuxFolders="@(LinuxFolder)"
+             CreateUser="$(CreateUser)"
+             InstallService="$(InstallService)"/>
   </Target>
 
   <Target Name="CreateTarball" DependsOnTargets="CreatePackageProperties">

--- a/demo/demo.csproj
+++ b/demo/demo.csproj
@@ -4,10 +4,23 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <RuntimeIdentifiers>win7-x64;rhel.7-x64</RuntimeIdentifiers>
     <PreserveCompilationContext>true</PreserveCompilationContext>
+    <CreateUser>true</CreateUser>
+    <InstallService>true</InstallService>
   </PropertyGroup>
   <PropertyGroup>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
   </PropertyGroup>
+  <ItemGroup>
+    <Content Update="appsettings.json">
+        <LinuxPath>/etc/demo/appsettings.json</LinuxPath>
+    </Content>
+    <Content Include="demo.service" CopyToPublishDirectory="PreserveNewest">
+        <LinuxPath>/etc/systemd/system/demo.service</LinuxPath>
+    </Content>
+    <LinuxFolder Include="/var/log/demo" Group="demo" Owner="demo" RemoveOnUninstall="true" />
+    <LinuxFolder Include="/var/run/demo" Group="demo" Owner="demo" RemoveOnUninstall="true" />
+    <LinuxFolder Include="/var/lib/demo" Group="demo" Owner="demo" RemoveOnUninstall="true" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.30" PrivateAssets="all" />
     <PackageReference Include="Packaging.Targets" Version="0.1.1-*" />

--- a/demo/demo.csproj
+++ b/demo/demo.csproj
@@ -20,6 +20,7 @@
     <LinuxFolder Include="/var/log/demo" Group="demo" Owner="demo" RemoveOnUninstall="true" />
     <LinuxFolder Include="/var/run/demo" Group="demo" Owner="demo" RemoveOnUninstall="true" />
     <LinuxFolder Include="/var/lib/demo" Group="demo" Owner="demo" RemoveOnUninstall="true" />
+    <RpmDependency Include="java-headless" Version="1.6.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.30" PrivateAssets="all" />

--- a/demo/demo.csproj
+++ b/demo/demo.csproj
@@ -20,7 +20,8 @@
     <LinuxFolder Include="/var/log/demo" Group="demo" Owner="demo" RemoveOnUninstall="true" />
     <LinuxFolder Include="/var/run/demo" Group="demo" Owner="demo" RemoveOnUninstall="true" />
     <LinuxFolder Include="/var/lib/demo" Group="demo" Owner="demo" RemoveOnUninstall="true" />
-    <RpmDependency Include="java-headless" Version="1.6.0" />
+    <RpmDependency Include="libunwind" Version="1.1" />
+    <RpmDependency Include="libicu" Version="50.1.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.30" PrivateAssets="all" />

--- a/demo/demo.service
+++ b/demo/demo.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=A sample service
+    
+[Service]
+ExecStart=/bin/sh -c 'while true; do echo "Running"; sleep 5; done'
+    
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds support for:

* **Adding additional files to the file system.**
Whereas the publish output goes to `/usr/share/<project-name>`, you may want to save additional files somewhere else. For example, you may want to store your `appsettings.json` file in `/etc/<project-name>/appsettings.json` or add a SystemD service file which you want to deploy to `/etc/systemd/system/demo.service`.
You can now do that by specifying the `LinuxPath` path on your project file. For example, to get redirect the location of the `appsettings.json` file, do:
```
<Content Update="appsettings.json">
   <LinuxPath>/etc/demo/appsettings.json</LinuxPath>
</Content>
```
* **Adding empty folders to the deployment layout**
By default, folders are not added to the package layout, even if they are empty. However, you may want to create folders such as `/var/lib/<project-name>` to store your app data.
You can add additional folder by adding `LinuxFolder` elements. You can also specify the owner and group of those folders, and whether these folders should be removed when your application is uninstalled.
```
<LinuxFolder Include="/var/log/demo" Group="demo" Owner="demo" RemoveOnUninstall="true" />
```
* **Specifying RPM dependencies**
Your application may depend on other RPM packages to run correctly. For example, any .NET Core application would depend on packages such as `libunwind`. You can now specify these dependencies using the `RpmDependency` element:
```
<RpmDependency Include="java-headless" Version="1.6.0" />
```
* **Creating Linux Users and Groups**
Applications which run as system services usually have a dedicated service account. You can now have dotnet-rpm create a user and group for your project when your application is installed:
```
<CreateUser>true</CreateUser>
```
* **Adding SystemD services**
`dotnet-rpm` can now install and start your SystemD service:
```
<InstallService>true</InstallService>
```