### PR TITLE
Fix netstandard2.0 compatibility

### DIFF
--- a/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
+++ b/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
@@ -8,6 +8,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+
+    <!-- The BouncyCastle dependency is defined as Private for Packaging.Targets, so we need to re-define it here. -->
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -27,6 +27,9 @@
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="NETStandard.Library" Version="2.0.0"/>
+  </ItemGroup>
   <ItemGroup>
     <Content Include="build\*.*">
       <Pack>true</Pack>

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -36,7 +36,7 @@
       <Pack>true</Pack>
       <PackagePath>lib\$(TargetFramework)\</PackagePath>
     </Content>
-    <Content Include="$(NugetPackageFolder)\portable.bouncycastle\1.8.1.2\lib\netstandard1.3\BouncyCastle.Crypto.dll" Link="BouncyCastle.Crypto.dll">
+    <Content Include="$(NugetPackageFolder)\portable.bouncycastle\1.8.1.3\lib\netstandard1.3\BouncyCastle.Crypto.dll" Link="BouncyCastle.Crypto.dll">
       <Pack>true</Pack>
       <PackagePath>lib\$(TargetFramework)\</PackagePath>
     </Content>

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -20,15 +20,23 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.409" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.409" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
-    <PackageReference Include="SharpZipLib.NETStandard" Version="0.86.0.1" />
+    <!-- MSBuild ships as part of the .NET CLI -->
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.409">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.409">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <!-- BoncyCastle and SharpZipLib are included in the lib\ folder in the Packaging.Targets package (see below), so we don't need an
+         explicit dependency on them, either -->
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="SharpZipLib.NETStandard" Version="0.86.0.1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="NETStandard.Library" Version="2.0.0"/>
   </ItemGroup>
   <ItemGroup>
     <Content Include="build\*.*">

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -43,11 +43,9 @@
       <Pack>true</Pack>
       <PackagePath>build\</PackagePath>
     </Content>
+    
+    <!-- SharpZipLib -->
     <Content Include="$(NugetPackageFolder)\sharpziplib.netstandard\0.86.0.1\lib\netstandard1.3\SharpZipLib.NETStandard.dll" Link="SharpZipLib.NETStandard.dll">
-      <Pack>true</Pack>
-      <PackagePath>lib\netstandard1.5\</PackagePath>
-    </Content>
-    <Content Include="$(NugetPackageFolder)\portable.bouncycastle\1.8.1.3\lib\netstandard1.3\BouncyCastle.Crypto.dll" Link="BouncyCastle.Crypto.dll">
       <Pack>true</Pack>
       <PackagePath>lib\netstandard1.5\</PackagePath>
     </Content>
@@ -55,7 +53,13 @@
       <Pack>true</Pack>
       <PackagePath>lib\netstandard2.0\</PackagePath>
     </Content>
+
+    <!-- Bouncy Castle-->
     <Content Include="$(NugetPackageFolder)\portable.bouncycastle\1.8.1.3\lib\netstandard1.3\BouncyCastle.Crypto.dll" Link="BouncyCastle.Crypto.dll">
+      <Pack>true</Pack>
+      <PackagePath>lib\netstandard1.5\</PackagePath>
+    </Content>
+    <Content Include="$(NugetPackageFolder)\portable.bouncycastle\1.8.1.3\lib\netstandard2.0\BouncyCastle.Crypto.dll" Link="BouncyCastle.Crypto.dll">
       <Pack>true</Pack>
       <PackagePath>lib\netstandard2.0\</PackagePath>
     </Content>

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netstandard1.5;netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard1.5;netstandard2.0</TargetFrameworks>
     <VersionPrefix>0.1.1</VersionPrefix>
     <NugetPackageFolder Condition="$(NugetPackageFolder) == ''">$(USERPROFILE)\.nuget\packages</NugetPackageFolder>
     <Authors>Frederik Carlier</Authors>

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard1.5;netstandard2.0</TargetFramework>
     <VersionPrefix>0.1.1</VersionPrefix>
     <NugetPackageFolder Condition="$(NugetPackageFolder) == ''">$(USERPROFILE)\.nuget\packages</NugetPackageFolder>
     <Authors>Frederik Carlier</Authors>
@@ -20,9 +20,9 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.2" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.409" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.409" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
     <PackageReference Include="SharpZipLib.NETStandard" Version="0.86.0.1" />
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -45,11 +45,19 @@
     </Content>
     <Content Include="$(NugetPackageFolder)\sharpziplib.netstandard\0.86.0.1\lib\netstandard1.3\SharpZipLib.NETStandard.dll" Link="SharpZipLib.NETStandard.dll">
       <Pack>true</Pack>
-      <PackagePath>lib\$(TargetFramework)\</PackagePath>
+      <PackagePath>lib\netstandard1.5\</PackagePath>
     </Content>
     <Content Include="$(NugetPackageFolder)\portable.bouncycastle\1.8.1.3\lib\netstandard1.3\BouncyCastle.Crypto.dll" Link="BouncyCastle.Crypto.dll">
       <Pack>true</Pack>
-      <PackagePath>lib\$(TargetFramework)\</PackagePath>
+      <PackagePath>lib\netstandard1.5\</PackagePath>
+    </Content>
+    <Content Include="$(NugetPackageFolder)\sharpziplib.netstandard\0.86.0.1\lib\netstandard1.3\SharpZipLib.NETStandard.dll" Link="SharpZipLib.NETStandard.dll">
+      <Pack>true</Pack>
+      <PackagePath>lib\netstandard2.0\</PackagePath>
+    </Content>
+    <Content Include="$(NugetPackageFolder)\portable.bouncycastle\1.8.1.3\lib\netstandard1.3\BouncyCastle.Crypto.dll" Link="BouncyCastle.Crypto.dll">
+      <Pack>true</Pack>
+      <PackagePath>lib\netstandard2.0\</PackagePath>
     </Content>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Mark the MSBuild, SharpZipLib and BouncyCastle dependencies as Private, so they don't show up as a NuGet dependency
- Include the SharpZipLib and BouncyCastle assemblies in the Packaging.Targets NuGet package, so they don't need to be acquired separately. We can ignore this for the MSBuild dependencies as they are already available on the build systems.