### PR TITLE
Minor RPM fixes

### DIFF
--- a/Packaging.Targets/RpmTask.cs
+++ b/Packaging.Targets/RpmTask.cs
@@ -154,13 +154,17 @@ namespace Packaging.Targets
                 cpioStream.Position = 0;
 
                 // Prepare the list of dependencies
-                var dependencies =
+                PackageDependency[] dependencies = Array.Empty<PackageDependency>();
+
+                if (this.RpmDependencies != null)
+                {
                     this.RpmDependencies.Select(
                         d => new PackageDependency(
                             d.ItemSpec,
                             RpmSense.RPMSENSE_EQUAL | RpmSense.RPMSENSE_GREATER,
                             d.GetVersion()))
                         .ToArray();
+                }
 
                 RpmPackageCreator rpmCreator = new RpmPackageCreator();
                 rpmCreator.CreatePackage(

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -11,6 +11,10 @@
       <PackagePath>$(TargetDir)$(PackageName)</PackagePath>
       <CreateUser Condition="'$(CreateUser)' == ''">false</CreateUser>
       <InstallService Condition="'$(InstallService)' == ''">false</InstallService>
+
+      <!-- Use the AssemblyFileVersion as the PackageVersion, but default to 1.0.0.0 if an AssemblyFileVersion has not been set. -->
+      <PackageVersion Condition="'$(AssemblyFileVersion)' != ''">$(AssemblyFileVersion)</PackageVersion>
+      <PackageVersion Condition="'$(AssemblyFileVersion)' == ''">1.0.0.0</PackageVersion>
     </PropertyGroup>
   </Target>
 
@@ -31,7 +35,7 @@
              RpmPath="$(RpmPath)"
              CpioPath="$(CpioPath)"
              Prefix="$(Prefix)"
-             Version="$(AssemblyFileVersion)"
+             Version="$(PackageVersion)"
              Release="$(Release)"
              PackageName="$(PackageName)"
              Content="@(Content)"


### PR DESCRIPTION
- Don't crash when no RPM dependencies have been specified
- Use 1.0.0.0 as the package version when the AssemblyFileVersion is not set.