### PR TITLE
Various fixed based on user feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 *.suo
 .vs/
 .idea/
+.vagrant/

--- a/Packaging.Targets/Native/FunctionLoader.cs
+++ b/Packaging.Targets/Native/FunctionLoader.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Packaging.Targets.Native
+{
+    /// <summary>
+    /// Supports loading functions from native libraries. Provides a more flexible alternative to P/Invoke.
+    /// </summary>
+    internal static class FunctionLoader
+    {
+        /// <summary>
+        /// Attempts to load a native library.
+        /// </summary>
+        /// <param name="windowsNames">
+        /// Possible names of the library on Windows. This can include full paths.
+        /// </param>
+        /// <param name="linuxNames">
+        /// Possible names of the library on Linux.
+        /// </param>
+        /// <param name="osxNames">
+        /// Possible names of the library on macOS.
+        /// </param>
+        /// <returns>
+        /// A handle to the library when found; otherwise, <see cref="IntPtr.Zero"/>.
+        /// </returns>
+        public static IntPtr LoadNativeLibrary(IEnumerable<string> windowsNames, IEnumerable<string> linuxNames, IEnumerable<string> osxNames)
+        {
+            IntPtr lib = IntPtr.Zero;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                foreach (var name in linuxNames)
+                {
+                    lib = NativeMethods.dlopen(name, NativeMethods.RTLD_NOW);
+
+                    if (lib != IntPtr.Zero)
+                    {
+                        break;
+                    }
+                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                foreach (var name in osxNames)
+                {
+                    lib = NativeMethods.dlopen(name, NativeMethods.RTLD_NOW);
+
+                    if (lib != IntPtr.Zero)
+                    {
+                        break;
+                    }
+                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                foreach (var name in windowsNames)
+                {
+                    lib = NativeMethods.LoadLibrary(name);
+
+                    if (lib != IntPtr.Zero)
+                    {
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            // This function may return a null handle. If it does, individual functions loaded from it will throw a DllNotFoundException,
+            // but not until an attempt is made to actually use the function (rather than load it). This matches how PInvokes behave.
+            return lib;
+        }
+
+        /// <summary>
+        /// Creates a delegate which invokes a native function.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The function delegate.
+        /// </typeparam>
+        /// <param name="nativeLibraryHandle">
+        /// The native library which contains the function.
+        /// </param>
+        /// <param name="functionName">
+        /// The name of the function for which to create the delegate.
+        /// </param>
+        /// <returns>
+        /// A new delegate which points to the native function.
+        /// </returns>
+        public static T LoadFunctionDelegate<T>(IntPtr nativeLibraryHandle, string functionName)
+        {
+            IntPtr ptr = LoadFunctionPointer(nativeLibraryHandle, functionName);
+
+            if (ptr == IntPtr.Zero)
+            {
+#if NETSTANDARD2_0
+                throw new EntryPointNotFoundException($"Could not find the entrypoint for {functionName}");
+#else
+                throw new Exception($"Could not find the entrypoint for {functionName}");
+#endif
+            }
+
+            return Marshal.GetDelegateForFunctionPointer<T>(ptr);
+        }
+
+        private static IntPtr LoadFunctionPointer(IntPtr nativeLibraryHandle, string functionName)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return NativeMethods.dlsym(nativeLibraryHandle, functionName);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return NativeMethods.dlsym(nativeLibraryHandle, functionName);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return NativeMethods.GetProcAddress(nativeLibraryHandle, functionName);
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
+            }
+        }
+    }
+}

--- a/Packaging.Targets/Native/FunctionLoader.cs
+++ b/Packaging.Targets/Native/FunctionLoader.cs
@@ -32,7 +32,7 @@ namespace Packaging.Targets.Native
             {
                 foreach (var name in linuxNames)
                 {
-                    lib = NativeMethods.dlopen(name, NativeMethods.RTLD_NOW);
+                    lib = LinuxNativeMethods.dlopen(name, LinuxNativeMethods.RTLD_NOW);
 
                     if (lib != IntPtr.Zero)
                     {
@@ -44,7 +44,7 @@ namespace Packaging.Targets.Native
             {
                 foreach (var name in osxNames)
                 {
-                    lib = NativeMethods.dlopen(name, NativeMethods.RTLD_NOW);
+                    lib = MacNativeMethods.dlopen(name, MacNativeMethods.RTLD_NOW);
 
                     if (lib != IntPtr.Zero)
                     {
@@ -56,7 +56,7 @@ namespace Packaging.Targets.Native
             {
                 foreach (var name in windowsNames)
                 {
-                    lib = NativeMethods.LoadLibrary(name);
+                    lib = WindowsNativeMethods.LoadLibrary(name);
 
                     if (lib != IntPtr.Zero)
                     {
@@ -109,15 +109,15 @@ namespace Packaging.Targets.Native
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                return NativeMethods.dlsym(nativeLibraryHandle, functionName);
+                return LinuxNativeMethods.dlsym(nativeLibraryHandle, functionName);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return NativeMethods.dlsym(nativeLibraryHandle, functionName);
+                return MacNativeMethods.dlsym(nativeLibraryHandle, functionName);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return NativeMethods.GetProcAddress(nativeLibraryHandle, functionName);
+                return WindowsNativeMethods.GetProcAddress(nativeLibraryHandle, functionName);
             }
             else
             {

--- a/Packaging.Targets/Native/LinuxNativeMethods.cs
+++ b/Packaging.Targets/Native/LinuxNativeMethods.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Packaging.Targets.Native
+{
+    internal static class LinuxNativeMethods
+    {
+        public const int RTLD_NOW = 0x002;
+
+        private const string Libdl = "libdl.so.2";
+
+        [DllImport(Libdl)]
+        public static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+        [DllImport(Libdl)]
+        public static extern IntPtr dlopen(string fileName, int flag);
+    }
+}

--- a/Packaging.Targets/Native/MacNativeMethods.cs
+++ b/Packaging.Targets/Native/MacNativeMethods.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Packaging.Targets.Native
+{
+    internal static class MacNativeMethods
+    {
+        public const int RTLD_NOW = 0x002;
+
+        private const string Libdl = "libdl";
+
+        [DllImport(Libdl)]
+        public static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+        [DllImport(Libdl)]
+        public static extern IntPtr dlopen(string fileName, int flag);
+    }
+}

--- a/Packaging.Targets/Native/NativeMethods.cs
+++ b/Packaging.Targets/Native/NativeMethods.cs
@@ -1,16 +1,17 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 
-namespace Packaging.Targets.IO
+namespace Packaging.Targets.Native
 {
-    internal static class SystemMethods
+    internal static class NativeMethods
     {
-        /// <summary>
-        /// The name of the <c>kernel32</c> library
-        /// </summary>
+        public const int RTLD_NOW = 0x002;
+
         private const string Kernel32 = "kernel32";
+        private const string Libdl = "libdl";
+
+        [DllImport(Kernel32, CharSet = CharSet.Ansi, BestFitMapping = false)]
+        public static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
 
         /// <summary>
         /// Loads the specified module into the address space of the calling process. The specified module may cause other modules to be loaded.
@@ -47,44 +48,10 @@ namespace Packaging.Targets.IO
         [DllImport(Kernel32, SetLastError = true)]
         public static extern IntPtr LoadLibrary(string dllToLoad);
 
-#pragma warning disable SA1300 // Element must begin with upper-case letter
-        /// <summary>
-        /// The function <see cref="dlopen"/> loads the dynamic library file named by the
-        /// null-terminated string filename.
-        /// </summary>
-        /// <param name="filename">
-        /// The path to the file to open.
-        /// </param>
-        /// <param name="flags">
-        /// A value of the <see cref="DlOpenFlags"/> enumeration specifying how the
-        /// dynamic library file is openend.
-        /// </param>
-        /// <returns>
-        /// Returns an opaque "handle" for the dynamic library.
-        /// </returns>
-        /// <remarks>
-        /// This method works on Linux only.
-        /// </remarks>
-        /// <seealso href="http://linux.die.net/man/3/dlopen"/>
-        [DllImport("libdl.so")]
-        public static extern IntPtr dlopen(string filename, DlOpenFlags flags);
+        [DllImport(Libdl)]
+        public static extern IntPtr dlsym(IntPtr handle, string symbol);
 
-        /// <summary>
-        /// The function <see cref="dlerror"/> returns a human readable string describing the most
-        /// recent error that occurred from <see cref="dlopen"/>, or <see cref="dlclose"/> since
-        /// the last call to <see cref="dlerror"/>. It returns <see cref="IntPtr.Zero"/> if no errors
-        /// have occurred since initialization or since it was last called.
-        /// </summary>
-        /// <returns>
-        /// A pointer to a human readable string describing the error, or <see cref="IntPtr.Zero"/>
-        /// if no error occurred.
-        /// </returns>
-        /// <remarks>
-        /// This method works on Linux only.
-        /// </remarks>
-        /// <seealso href="http://linux.die.net/man/3/dlopen"/>
-        [DllImport("libdl.so")]
-        public static extern IntPtr dlerror();
-#pragma warning restore SA1300 // Element must begin with upper-case letter
+        [DllImport(Libdl)]
+        public static extern IntPtr dlopen(string fileName, int flag);
     }
 }

--- a/Packaging.Targets/Native/WindowsNativeMethods.cs
+++ b/Packaging.Targets/Native/WindowsNativeMethods.cs
@@ -3,12 +3,9 @@ using System.Runtime.InteropServices;
 
 namespace Packaging.Targets.Native
 {
-    internal static class NativeMethods
+    internal static class WindowsNativeMethods
     {
-        public const int RTLD_NOW = 0x002;
-
         private const string Kernel32 = "kernel32";
-        private const string Libdl = "libdl";
 
         [DllImport(Kernel32, CharSet = CharSet.Ansi, BestFitMapping = false)]
         public static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
@@ -47,11 +44,5 @@ namespace Packaging.Targets.Native
         /// <seealso href="http://msdn.microsoft.com/en-us/library/windows/desktop/ms684175(v=vs.85).aspx"/>
         [DllImport(Kernel32, SetLastError = true)]
         public static extern IntPtr LoadLibrary(string dllToLoad);
-
-        [DllImport(Libdl)]
-        public static extern IntPtr dlsym(IntPtr handle, string symbol);
-
-        [DllImport(Libdl)]
-        public static extern IntPtr dlopen(string fileName, int flag);
     }
 }

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -38,7 +38,14 @@
     <PackageReference Include="SharpZipLib.NETStandard" Version="0.86.0.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="SharpZipLib.NETStandard" Version="0.86.0.1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
   </ItemGroup>

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -6,18 +6,20 @@
 
   <Target Name="CreatePackageProperties" DependsOnTargets="Publish">
     <PropertyGroup>
+
+      <!-- Use the Version as the PackageVersion, but default to 1.0.0 if an Version has not been set
+           and allow the user to override this. -->
+      <PackageVersion Condition="'$(PackageVersion)' == '' AND '$(Version)' != ''">$(Version)</PackageVersion>
+      <PackageVersion Condition="'$(PackageVersion)' == '' AND '$(Version)' == ''">1.0.0</PackageVersion>
+      
       <PackagePrefix Condition="'$(PackagePrefix)' == ''">$(TargetName)</PackagePrefix>
-      <PackageName Condition="'$(PackageName)' == ''">$(PackagePrefix).$(AssemblyFileVersion).$(RuntimeIdentifier)</PackageName>
+      <PackageName Condition="'$(PackageName)' == ''">$(PackagePrefix).$(PackageVersion).$(RuntimeIdentifier)</PackageName>
       <IntermediatePackagePath>$(IntermediateOutputPath)$(PackageName)</IntermediatePackagePath>
       <PackagePath Condition="'$(PackagePath)' == ''">$(TargetDir)$(PackageName)</PackagePath>
       <CreateUser Condition="'$(CreateUser)' == ''">false</CreateUser>
       <InstallService Condition="'$(InstallService)' == ''">false</InstallService>
       <PackageMaintainer Condition="'$(PackageMaintainer)' == ''">Anonymous &lt;noreply@example.com&gt;</PackageMaintainer>
       <PackageDescription Condition="'$(PackageDescription)' == ''">$(PackageName)</PackageDescription>
-                         
-      <!-- Use the AssemblyFileVersion as the PackageVersion, but default to 1.0.0.0 if an AssemblyFileVersion has not been set. -->
-      <PackageVersion Condition="'$(AssemblyFileVersion)' != ''">$(AssemblyFileVersion)</PackageVersion>
-      <PackageVersion Condition="'$(AssemblyFileVersion)' == ''">1.0.0.0</PackageVersion>
     </PropertyGroup>
   </Target>
 

--- a/boxes/fedora.25/Vagrantfile
+++ b/boxes/fedora.25/Vagrantfile
@@ -1,0 +1,17 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "fedora/25-cloud-base"
+  config.vm.box_version = "20161122"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provision "shell", inline: <<-SHELL
+    echo "vagrant:vagrant" | chpasswd
+
+    rpm --import https://packages.microsoft.com/keys/microsoft.asc
+    sh -c 'echo -e "[packages-microsoft-com-prod]\nname=packages-microsoft-com-prod \nbaseurl=https://packages.microsoft.com/yumrepos/microsoft-rhel7.3-prod\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/dotnetdev.repo'
+    dnf update -y
+    dnf install -y libunwind libicu
+    dnf install -y dotnet-sdk-2.0.0
+
+    dotnet --version
+  SHELL
+end

--- a/boxes/rhel7.3/Vagrantfile
+++ b/boxes/rhel7.3/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "iamseth/rhel-7.3"
+  config.vm.box_version = "1.0.0"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    echo "vagrant:vagrant" | chpasswd
+    wget -nv -nc https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-linux-x64.tar.gz -O dotnet-sdk-2.0.0-linux-x64.tar.gz
+    mkdir -p $HOME/dotnet
+    tar zxf dotnet-sdk-2.0.0-linux-x64.tar.gz -C $HOME/dotnet
+    echo "export PATH=$PATH:$HOME/dotnet" >> ~/.bashrc
+
+    wget ftp://195.220.108.108/linux/centos/7.4.1708/os/x86_64/Packages/libunwind-1.2-2.el7.x86_64.rpm
+    yum install -y libunwind-1.2-2.el7.x86_64.rpm
+
+    wget ftp://195.220.108.108/linux/centos/7.3.1611/os/x86_64/Packages/libicu-50.1.2-15.el7.x86_64.rpm
+    yum install -y libicu-50.1.2-15.el7.x86_64.rpm
+
+    $HOME/dotnet/dotnet --version
+  SHELL
+end

--- a/boxes/rhel7.3/Vagrantfile
+++ b/boxes/rhel7.3/Vagrantfile
@@ -18,6 +18,14 @@ Vagrant.configure("2") do |config|
     wget ftp://195.220.108.108/linux/centos/7.3.1611/os/x86_64/Packages/libicu-50.1.2-15.el7.x86_64.rpm
     yum install -y libicu-50.1.2-15.el7.x86_64.rpm
 
+    wget http://ftp.tu-chemnitz.de/pub/linux/dag/redhat/el7/en/x86_64/rpmforge/RPMS/lzma-devel-4.32.7-1.el7.rf.x86_64.rpm
+    wget http://ftp.tu-chemnitz.de/pub/linux/dag/redhat/el7/en/x86_64/rpmforge/RPMS/lzma-libs-4.32.7-1.el7.rf.x86_64.rpm
+
+    yum install -y lzma-libs-4.32.7-1.el7.rf.x86_64.rpm
+    yum install -y lzma-devel-4.32.7-1.el7.rf.x86_64.rpm
+
+    ln -s /usr/lib64/liblzma.so.5 /usr/lib64/liblzma.so
+
     $HOME/dotnet/dotnet --version
   SHELL
 end


### PR DESCRIPTION
- Better compatibility with different Linux distributions: P/Invoke `libdl.so.2` instead of `libdl.so`, and load `libzlma` with and without the `.5` version suffix
- Use `$(Version)` instead of `$(AssemblyFileVersion)` as the input to the package version; this property defaults to `1.0.0` on .NET Core so we don't get empty values
- Make StyleCop a private asset, so dependent projects are not forced to use StyleCop
- Add Vagrant boxes for RHEL and Fedora for testing purposes.