### PR TITLE
Don't fail if lzma_stream_encoder_mt is not available

### DIFF
--- a/Packaging.Targets/IO/XZOutputStream.cs
+++ b/Packaging.Targets/IO/XZOutputStream.cs
@@ -67,7 +67,7 @@ namespace Packaging.Targets.IO
             this.leaveOpen = leaveOpen;
 
             LzmaResult ret;
-            if (threads == 1)
+            if (threads == 1 || !NativeMethods.SupportsMultiThreading)
             {
                 ret = NativeMethods.lzma_easy_encoder(ref this.lzmaStream, preset, LzmaCheck.Crc64);
             }

--- a/Packaging.Targets/Native/FunctionLoader.cs
+++ b/Packaging.Targets/Native/FunctionLoader.cs
@@ -89,17 +89,25 @@ namespace Packaging.Targets.Native
         /// <returns>
         /// A new delegate which points to the native function.
         /// </returns>
-        public static T LoadFunctionDelegate<T>(IntPtr nativeLibraryHandle, string functionName)
+        public static T LoadFunctionDelegate<T>(IntPtr nativeLibraryHandle, string functionName, bool throwOnError = true)
+            where T : class
         {
             IntPtr ptr = LoadFunctionPointer(nativeLibraryHandle, functionName);
 
             if (ptr == IntPtr.Zero)
             {
+                if (throwOnError)
+                {
 #if NETSTANDARD2_0
-                throw new EntryPointNotFoundException($"Could not find the entrypoint for {functionName}");
+                    throw new EntryPointNotFoundException($"Could not find the entrypoint for {functionName}");
 #else
-                throw new Exception($"Could not find the entrypoint for {functionName}");
+                    throw new Exception($"Could not find the entrypoint for {functionName}");
 #endif
+                }
+                else
+                {
+                    return null;
+                }
             }
 
             return Marshal.GetDelegateForFunctionPointer<T>(ptr);


### PR DESCRIPTION
This can happen on Ubuntu and other Linux platforms. In that case, just always use single-threaded compression.