### PR TITLE
Debian: Fix pre/post install script mixup

### DIFF
--- a/Packaging.Targets/Deb/DebPackageCreator.cs
+++ b/Packaging.Targets/Deb/DebPackageCreator.cs
@@ -118,7 +118,7 @@ namespace Packaging.Targets.Deb
 
             if (string.IsNullOrWhiteSpace(pkg.PostInstallScript))
             {
-                WriteControlEntry(controlTar, "./preinst", $"#!/bin/sh\n{pkg.PostInstallScript}\n", execMode);
+                WriteControlEntry(controlTar, "./postinst", $"#!/bin/sh\n{pkg.PostInstallScript}\n", execMode);
             }
 
             if (string.IsNullOrWhiteSpace(pkg.PreRemoveScript))


### PR DESCRIPTION
Fix issue where the post install script was written to the 'preinst' file instead of 'postinst'.

Fixes #32