### PR TITLE
Deb: Additional control fields

### DIFF
--- a/Packaging.Targets/Deb/DebPackageCreator.cs
+++ b/Packaging.Targets/Deb/DebPackageCreator.cs
@@ -26,6 +26,9 @@ namespace Packaging.Targets.Deb
             bool installService,
             string serviceName,
             string prefix,
+            string section,
+            string priority,
+            string homepage,
             IEnumerable<string> additionalDependencies,
             Action<DebPackage> additionalMetadata,
             Stream targetStream)
@@ -43,9 +46,25 @@ namespace Packaging.Targets.Deb
                     ["Version"] = version,
                     ["Architecture"] = arch,
                     ["Maintainer"] = maintainer,
-                    ["Description"] = description
+                    ["Description"] = description,
+                    ["Install-Size"] = (archiveEntries.Sum(e => e.FileSize) / 1024).ToString()
                 }
             };
+
+            if (!string.IsNullOrEmpty(section))
+            {
+                pkg.ControlFile["Section"] = section;
+            }
+
+            if (!string.IsNullOrEmpty(priority))
+            {
+                pkg.ControlFile["Priority"] = priority;
+            }
+
+            if (!string.IsNullOrEmpty(homepage))
+            {
+                pkg.ControlFile["Homepage"] = homepage;
+            }
 
             if (createUser)
             {

--- a/Packaging.Targets/DebTask.cs
+++ b/Packaging.Targets/DebTask.cs
@@ -44,6 +44,12 @@ namespace Packaging.Targets
         [Required]
         public string Description { get; set; }
 
+        public string Section { get; set; }
+
+        public string Homepage { get; set; }
+
+        public string Priority { get; set; }
+
         /// <summary>
         /// Gets or sets a list of empty folders to create when
         /// installing this package.
@@ -152,6 +158,9 @@ namespace Packaging.Targets
                         this.InstallService,
                         this.ServiceName,
                         this.Prefix,
+                        this.Section,
+                        this.Priority,
+                        this.Homepage,
                         dependencies,
                         null,
                         targetStream);

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -61,6 +61,9 @@
       <PackageName>$(PackagePrefix)</PackageName>
       <UserName Condition="'$(UserName)' == ''">$(PackagePrefix)</UserName>
       <ServiceName Condition="'$(ServiceName)' == ''">$(PackagePrefix)</ServiceName >
+      <DebSection Condition="'$(Section)' == ''">misc</DebSection>
+      <DebPriority Condition="'$(DebPriority)' == ''">extra</DebPriority>
+      <DebHomepage Condition="'$(DebHomepage)' == ''">$(PackageProjectUrl)</DebHomepage>
     </PropertyGroup>
     
     <!-- Dependency list from https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/jessie/amd64/Dockerfile 
@@ -95,7 +98,10 @@
              Description="$(PackageDescription)"
              UserName="$(UserName)"
              InstallService="$(InstallService)"
-             ServiceName="$(ServiceName)"/>
+             ServiceName="$(ServiceName)"
+             Section="$(DebSection)"
+             Priority="$(DebPriority)"
+             Homepage="$(DebHomepage)"/>
   </Target>
 
   <Target Name="CreateTarball" DependsOnTargets="CreatePackageProperties">


### PR DESCRIPTION
Add support for the `Section`, `Homepage`, `Priority` and `Installed-Size` control fields.

For `Section` and `Priority`, I used `misc` and `extra` as the default values. `Install-Size` is calculated based on all the entries which go into the CPIO archive. `Homepage` is by default set to the value of the `PackageProjectUrl` variable.

You can override `Section`, `Homepage` and `Priority` by setting the `DebSection`, `DebHomepage` and `DebPriority` msbuild variables.