### PR TITLE
Allow users to override the Linux file mode of files

### DIFF
--- a/Packaging.Targets.Tests/ArchiveBuilderTests.cs
+++ b/Packaging.Targets.Tests/ArchiveBuilderTests.cs
@@ -1,0 +1,103 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Packaging.Targets.IO;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Packaging.Targets.Tests
+{
+    /// <summary>
+    /// Tests the <see cref="ArchiveBuilder"/> class.
+    /// </summary>
+    public class ArchiveBuilderTests
+    {
+        /// <summary>
+        /// Tests the <see cref="ArchiveBuilder.FromDirectory(string, string, ITaskItem[])"/> method
+        /// </summary>
+        [Fact]
+        public void FromDirectoryTest()
+        {
+            ArchiveBuilder builder = new ArchiveBuilder();
+            var entries = builder.FromDirectory("archive", "/opt/demo", Array.Empty<ITaskItem>());
+
+            Assert.Equal(2, entries.Count);
+
+            var readme = entries[0];
+            Assert.Equal("root", readme.Group);
+            Assert.Equal(1L, readme.Inode);
+            Assert.False(readme.IsAscii);
+            Assert.Equal(string.Empty, readme.LinkTo);
+            Assert.Equal(LinuxFileMode.S_IROTH |  LinuxFileMode.S_IRGRP |  LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFREG, readme.Mode);
+            Assert.Equal("root", readme.Owner);
+            Assert.False(readme.RemoveOnUninstall);
+            Assert.Equal("archive\\README.md", readme.SourceFilename);
+            Assert.Equal("/opt/demo/README.md", readme.TargetPath);
+            Assert.Equal("/opt/demo/README.md", readme.TargetPathWithFinalSlash);
+            Assert.Equal(ArchiveEntryType.None, readme.Type);
+
+            var script = entries[1];
+            Assert.Equal("root", script.Group);
+            Assert.Equal(2L, script.Inode);
+            Assert.False(script.IsAscii);
+            Assert.Equal(string.Empty, script.LinkTo);
+            Assert.Equal(LinuxFileMode.S_IROTH | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFREG, script.Mode);
+            Assert.Equal("root", script.Owner);
+            Assert.False(script.RemoveOnUninstall);
+            Assert.Equal("archive\\script.sh", script.SourceFilename);
+            Assert.Equal("/opt/demo/script.sh", script.TargetPath);
+            Assert.Equal("/opt/demo/script.sh", script.TargetPathWithFinalSlash);
+            Assert.Equal(ArchiveEntryType.None, script.Type);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="ArchiveBuilder.FromDirectory(string, string, ITaskItem[])"/> method
+        /// </summary>
+        [Fact]
+        public void FromDirectoryWithMetadataTest()
+        {
+            ArchiveBuilder builder = new ArchiveBuilder();
+
+            Dictionary<string, string> metadata = new Dictionary<string, string>()
+            {
+                { "CopyToPublishDirectory", "Always" },
+                { "LinuxPath", "/bin/script.sh" },
+                { "LinuxFileMode", "755" },
+            };
+
+            var taskItem = new TaskItem("script.sh", metadata);
+            var taskItems = new ITaskItem[] { taskItem };
+            var entries = builder.FromDirectory("archive", "/opt/demo", taskItems);
+
+            Assert.Equal(2, entries.Count);
+
+            var readme = entries[0];
+            Assert.Equal("root", readme.Group);
+            Assert.Equal(1L, readme.Inode);
+            Assert.False(readme.IsAscii);
+            Assert.Equal(string.Empty, readme.LinkTo);
+            Assert.Equal(LinuxFileMode.S_IROTH | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFREG, readme.Mode);
+            Assert.Equal("root", readme.Owner);
+            Assert.False(readme.RemoveOnUninstall);
+            Assert.Equal("archive\\README.md", readme.SourceFilename);
+            Assert.Equal("/opt/demo/README.md", readme.TargetPath);
+            Assert.Equal("/opt/demo/README.md", readme.TargetPathWithFinalSlash);
+            Assert.Equal(ArchiveEntryType.None, readme.Type);
+
+            var script = entries[1];
+            Assert.Equal("root", script.Group);
+            Assert.Equal(2L, script.Inode);
+            Assert.False(script.IsAscii);
+            Assert.Equal(string.Empty, script.LinkTo);
+
+            // -rwxr-xr-x
+            Assert.Equal(LinuxFileMode.S_IXOTH | LinuxFileMode.S_IROTH | LinuxFileMode.S_IXGRP | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IXUSR | LinuxFileMode.S_IWUSR | LinuxFileMode.S_IRUSR, script.Mode);
+            Assert.Equal("root", script.Owner);
+            Assert.False(script.RemoveOnUninstall);
+            Assert.Equal("archive\\script.sh", script.SourceFilename);
+            Assert.Equal("/bin/script.sh", script.TargetPath);
+            Assert.Equal("/bin/script.sh", script.TargetPathWithFinalSlash);
+            Assert.Equal(ArchiveEntryType.None, script.Type);
+        }
+    }
+}

--- a/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
+++ b/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
@@ -6,11 +6,18 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="xunit.analyzers">
+      <Version>0.7.0</Version>
+    </PackageReference>
 
     <!-- The BouncyCastle dependency is defined as Private for Packaging.Targets, so we need to re-define it here. -->
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
+
+    <!-- Defined as a private dependency, so we need to re-define it here -->
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.409" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.409" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,6 +29,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="archive\README.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="archive\script.sh">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Deb\libplist3_1.12-3.1_amd64.deb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Packaging.Targets.Tests/archive/README.md
+++ b/Packaging.Targets.Tests/archive/README.md
@@ -1,0 +1,1 @@
+﻿This is a sample readme file.

--- a/Packaging.Targets.Tests/archive/script.sh
+++ b/Packaging.Targets.Tests/archive/script.sh
@@ -1,0 +1,3 @@
+﻿#! /bin/sh
+
+echo 'This is a sample script'

--- a/Packaging.Targets/TaskItemExtensions.cs
+++ b/Packaging.Targets/TaskItemExtensions.cs
@@ -80,6 +80,20 @@ namespace Packaging.Targets
         }
 
         /// <summary>
+        /// Gets the file mode of the file in the Linux filesystem.
+        /// </summary>
+        /// <param name="item">
+        /// The item for which to get the file mode.
+        /// </param>
+        /// <returns>
+        /// The file mode of the file on the Linux file system.
+        /// </returns>
+        public static string GetLinuxFileMode(this ITaskItem item)
+        {
+            return TryGetValue(item, "LinuxFileMode");
+        }
+
+        /// <summary>
         /// Gets the Linux owner of the file.
         /// </summary>
         /// <param name="item">


### PR DESCRIPTION
This PR allows you to add a new attribute to files, the `LinuxFileMode` attribute, which you can use to set the file mode of the file on Linux file systems in octal notation.

For example, to give root root `rwx` and others `rx` permissions, you can specify `LinuxFileMode="755"` in your `.csproj` file.

Fixes #31 