### PR TITLE
Don't remove entries on upgrade

### DIFF
--- a/Packaging.Targets/Rpm/RpmPackageCreator.cs
+++ b/Packaging.Targets/Rpm/RpmPackageCreator.cs
@@ -292,7 +292,11 @@ namespace Packaging.Targets.Rpm
             // Remove all directories marked as such (these are usually directories which contain temporary files)
             foreach (var entryToRemove in archiveEntries.Where(e => e.RemoveOnUninstall))
             {
-                preUn += $"/usr/bin/rm -rf {entryToRemove.TargetPath}\n";
+                preUn +=
+                    $"if [ $1 -eq 0 ] ; then \n" +
+                    $"    # Package removal, not upgrade \n" +
+                    $"    /usr/bin/rm -rf {entryToRemove.TargetPath}\n" +
+                    $"fi\n";
             }
 
             if (!string.IsNullOrEmpty(preIn))


### PR DESCRIPTION
We will remove entries with `RemoveOnUninstall` via a `preun` script. This script also runs when the package is being upgraded.

Mark this script with a condition `$1 -eq 0` to detect package uninstall rather than upgrade.