### PR TITLE
Deb Install Service Fix

### DIFF
--- a/Packaging.Targets.Tests/Deb/DebPackageCreatorTests.cs
+++ b/Packaging.Targets.Tests/Deb/DebPackageCreatorTests.cs
@@ -132,7 +132,7 @@ namespace Packaging.Targets.Tests.Deb
 /usr/sbin/useradd -g demouser -s /sbin/nologin -r -d /opt/local demouser 2>/dev/null || :
 echo 'Hello from pre install'
 ", pkg.PreInstallScript, ignoreLineEndingDifferences: true);
-            Assert.Equal(@"systemctl reload
+            Assert.Equal(@"systemctl daemon-reload
 systemctl enable --now demoservice.service
 echo 'Hello from post install'
 ", pkg.PostInstallScript, ignoreLineEndingDifferences: true);

--- a/Packaging.Targets/Deb/DebPackageCreator.cs
+++ b/Packaging.Targets/Deb/DebPackageCreator.cs
@@ -79,7 +79,7 @@ namespace Packaging.Targets.Deb
             if (installService)
             {
                 // Install and activate the service.
-                pkg.PostInstallScript += $"systemctl reload\n";
+                pkg.PostInstallScript += $"systemctl daemon-reload\n";
                 pkg.PostInstallScript += $"systemctl enable --now {serviceName}.service\n";
                 pkg.PreRemoveScript += $"systemctl --no-reload disable --now {serviceName}.service\n";
             }


### PR DESCRIPTION
Fix issue where 'systemctl reload' was being called upon InstallService rather than 'systemctl daemon-reload'. This was causing a 'too few arguments' error.

