### PR TITLE
Issue61

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/dotnet-deb/bin/Debug/netcoreapp1.0/dotnet-deb.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/dotnet-deb",
+            // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ,]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/dotnet-deb/dotnet-deb.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/Packaging.Targets.Tests/Rpm/RpmMetadataTests.cs
+++ b/Packaging.Targets.Tests/Rpm/RpmMetadataTests.cs
@@ -117,7 +117,7 @@ namespace Packaging.Targets.Tests.Rpm
                 {
                     ArchiveBuilder builder = new ArchiveBuilder(new PlistFileAnalyzer());
                     RpmPackageCreator creator = new RpmPackageCreator(new PlistFileAnalyzer());
-                    var entries = builder.FromCpio(cpio);
+                    var entries = builder.FromCpio(originalPackage, cpio);
                     var files = creator.CreateFiles(entries);
 
                     var metadata = new PublicRpmMetadata(package);
@@ -186,7 +186,7 @@ namespace Packaging.Targets.Tests.Rpm
                 {
                     ArchiveBuilder builder = new ArchiveBuilder(new PlistFileAnalyzer());
                     RpmPackageCreator creator = new RpmPackageCreator(new PlistFileAnalyzer());
-                    var entries = builder.FromCpio(cpio);
+                    var entries = builder.FromCpio(originalPackage, cpio);
                     var files = creator.CreateFiles(entries);
 
                     // Core routine to populate files and dependencies

--- a/Packaging.Targets.Tests/Rpm/RpmPackageCreatorTests.cs
+++ b/Packaging.Targets.Tests/Rpm/RpmPackageCreatorTests.cs
@@ -46,7 +46,7 @@ namespace Packaging.Targets.Tests.Rpm
 
                     RpmPackageCreator creator = new RpmPackageCreator(analyzer);
                     ArchiveBuilder builder = new ArchiveBuilder(analyzer);
-                    var entries = builder.FromCpio(cpio);
+                    var entries = builder.FromCpio(originalPackage, cpio);
                     var files = creator.CreateFiles(entries);
 
                     var originalMetadata = new RpmMetadata(originalPackage);
@@ -98,7 +98,7 @@ namespace Packaging.Targets.Tests.Rpm
                 {
                     ArchiveBuilder builder = new ArchiveBuilder(new PlistFileAnalyzer());
                     RpmPackageCreator creator = new RpmPackageCreator(new PlistFileAnalyzer());
-                    var entries = builder.FromCpio(cpio);
+                    var entries = builder.FromCpio(originalPackage, cpio);
                     var files = creator.CreateFiles(entries);
 
                     // Core routine to populate files and dependencies
@@ -151,7 +151,7 @@ namespace Packaging.Targets.Tests.Rpm
                 using (var cpio = new CpioFile(payloadStream, false))
                 {
                     ArchiveBuilder builder = new ArchiveBuilder(new PlistFileAnalyzer());
-                    var entries = builder.FromCpio(cpio);
+                    var entries = builder.FromCpio(originalPackage, cpio);
                     files = creator.CreateFiles(entries);
                 }
 
@@ -253,7 +253,7 @@ namespace Packaging.Targets.Tests.Rpm
                 using (CpioFile cpio = new CpioFile(decompressedPayloadStream, leaveOpen: false))
                 {
                     ArchiveBuilder builder = new ArchiveBuilder();
-                    archive = builder.FromCpio(cpio);
+                    archive = builder.FromCpio(originalPackage, cpio);
                 }
 
                 using (var decompressedPayloadStream = RpmPayloadReader.GetDecompressedPayloadStream(originalPackage))
@@ -318,7 +318,7 @@ namespace Packaging.Targets.Tests.Rpm
                 using (CpioFile cpio = new CpioFile(decompressedPayloadStream, leaveOpen: false))
                 {
                     ArchiveBuilder builder = new ArchiveBuilder();
-                    archive = builder.FromCpio(cpio);
+                    archive = builder.FromCpio(originalPackage, cpio);
                 }
 
                 using (var compressedPayloadStream = RpmPayloadReader.GetCompressedPayloadStream(originalPackage))

--- a/Packaging.Targets/IO/ArchiveEntryType.cs
+++ b/Packaging.Targets/IO/ArchiveEntryType.cs
@@ -18,6 +18,16 @@
         /// <summary>
         /// The file is a 64-bit executable.
         /// </summary>
-        Executable64 = 2
+        Executable64 = 2,
+
+        /// <summary>
+        /// The file is a module (like a .NET assembly)
+        /// </summary>
+        NetAssembly = 3,
+
+        /// <summary>
+        /// This file is a documentation entry
+        /// </summary>
+        Doc = 4
     }
 }

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -50,6 +50,7 @@
     <PackageReference Include="SharpZipLib.NETStandard" Version="0.86.0.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />

--- a/Packaging.Targets/Rpm/FileAnalyzer.cs
+++ b/Packaging.Targets/Rpm/FileAnalyzer.cs
@@ -33,15 +33,7 @@ namespace Packaging.Targets.Rpm
         /// <inheritdoc/>
         public virtual RpmFileFlags DetermineFlags(ArchiveEntry entry)
         {
-            if (entry.Mode.HasFlag(LinuxFileMode.S_IFDIR))
-            {
-                return RpmFileFlags.None;
-            }
-            else if (entry.Mode.HasFlag(LinuxFileMode.S_IFLNK))
-            {
-                return RpmFileFlags.None;
-            }
-            else if (entry.Type == ArchiveEntryType.Doc)
+            if (entry.Type == ArchiveEntryType.Doc)
             {
                 return RpmFileFlags.RPMFILE_DOC;
             }

--- a/Packaging.Targets/Rpm/FileAnalyzer.cs
+++ b/Packaging.Targets/Rpm/FileAnalyzer.cs
@@ -33,8 +33,6 @@ namespace Packaging.Targets.Rpm
         /// <inheritdoc/>
         public virtual RpmFileFlags DetermineFlags(ArchiveEntry entry)
         {
-            // The only custom flags which are supported for now are the RPMFILE_DOC flags for non-executable
-            // files.
             if (entry.Mode.HasFlag(LinuxFileMode.S_IFDIR))
             {
                 return RpmFileFlags.None;
@@ -43,9 +41,7 @@ namespace Packaging.Targets.Rpm
             {
                 return RpmFileFlags.None;
             }
-            else if (!entry.Mode.HasFlag(LinuxFileMode.S_IXGRP)
-                    && !entry.Mode.HasFlag(LinuxFileMode.S_IXOTH)
-                    && !entry.Mode.HasFlag(LinuxFileMode.S_IXUSR))
+            else if (entry.Type == ArchiveEntryType.Doc)
             {
                 return RpmFileFlags.RPMFILE_DOC;
             }
@@ -66,6 +62,9 @@ namespace Packaging.Targets.Rpm
 
                 case ArchiveEntryType.Executable64:
                     return RpmFileColor.RPMFC_ELF64;
+
+                case ArchiveEntryType.NetAssembly:
+                    return RpmFileColor.RPMFC_INCLUDE;
 
                 default:
                     return RpmFileColor.RPMFC_BLACK;
@@ -90,6 +89,11 @@ namespace Packaging.Targets.Rpm
             if (entry.Mode.HasFlag(LinuxFileMode.S_IFLNK))
             {
                 return string.Empty;
+            }
+
+            if (entry.Type == ArchiveEntryType.NetAssembly)
+            {
+                return "mono";
             }
 
             if (entry.TargetPath.EndsWith(".svg"))

--- a/Packaging.Targets/Rpm/RpmFileColor.cs
+++ b/Packaging.Targets/Rpm/RpmFileColor.cs
@@ -2,41 +2,21 @@
 
 namespace Packaging.Targets.Rpm
 {
+    /*
+     * from https://github.com/rpm-software-management/rpm/blob/master/build/rpmfc.h
+     */
+
     /// <summary>
     /// Determines the type of the file.
     /// </summary>
     [Flags]
-    internal enum RpmFileColor
+    internal enum RpmFileColor : int
     {
         RPMFC_BLACK = 0,
         RPMFC_ELF32 = 1 << 0,
         RPMFC_ELF64 = 1 << 1,
         RPMFC_ELFMIPSN32 = 1 << 2,
-        RPMFC_PKGCONFIG = 1 << 4,
-        RPMFC_LIBTOOL = 1 << 5,
-        RPMFC_BOURNE = 1 << 6,
-        RPMFC_MODULE = 1 << 7,
-        RPMFC_EXECUTABLE = 1 << 8,
-        RPMFC_SCRIPT = 1 << 9,
-        RPMFC_TEXT = 1 << 10,
-        RPMFC_DATA = 1 << 11,
-        RPMFC_DOCUMENT = 1 << 12,
-        RPMFC_STATIC = 1 << 13,
-        RPMFC_NOTSTRIPPED = 1 << 14,
-        RPMFC_COMPRESSED = 1 << 15,
-        RPMFC_DIRECTORY = 1 << 16,
-        RPMFC_SYMLINK = 1 << 17,
-        RPMFC_DEVICE = 1 << 18,
-        RPMFC_LIBRARY = 1 << 19,
-        RPMFC_ARCHIVE = 1 << 20,
-        RPMFC_FONT = 1 << 21,
-        RPMFC_IMAGE = 1 << 22,
-        RPMFC_MANPAGE = 1 << 23,
-        RPMFC_PERL = 1 << 24,
-        RPMFC_JAVA = 1 << 25,
-        RPMFC_PYTHON = 1 << 26,
-        RPMFC_PHP = 1 << 27,
-        RPMFC_TCL = 1 << 28,
+        RPMFC_ELF = RPMFC_ELF32 | RPMFC_ELF64 | RPMFC_ELFMIPSN32,
         RPMFC_WHITE = 1 << 29,
         RPMFC_INCLUDE = 1 << 30,
         RPMFC_ERROR = 1 << 31

--- a/Packaging.Targets/TaskItemExtensions.cs
+++ b/Packaging.Targets/TaskItemExtensions.cs
@@ -94,6 +94,26 @@ namespace Packaging.Targets
         }
 
         /// <summary>
+        /// Gets the file mode of the file in the Linux filesystem.
+        /// </summary>
+        /// <param name="item">
+        /// The item for which to get the file mode.
+        /// </param>
+        /// <returns>
+        /// The file mode of the file on the Linux file system.
+        /// </returns>
+        public static bool GetDocumentation(this ITaskItem item)
+        {
+            var docValue = TryGetValue(item, "Documentation");
+            if (docValue != null)
+            {
+                return docValue.ToLower().Equals("true");
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Gets the Linux owner of the file.
         /// </summary>
         /// <param name="item">


### PR DESCRIPTION
[Discussion item. Not yet ready to merge]

PR to resolve issue #61 - proposes a range of changes to improve the accuracy of the test scenarios that read back existing RPM package by taking their metadata into account, introduces explicit archive file types for .NET assemblies and documentation files, adds detection for .NET assemblies, and adds a metadata extension to explicitly flag documentation files.