### PR TITLE
Don't start branch builds if a PR is active

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 image: Visual Studio 2017
 
 version: '0.1.{build}'
+skip_branch_with_pr: true
 
 before_build:
   - dotnet restore dotnet-packaging.sln


### PR DESCRIPTION
Otherwise we'll get two builds for each branch in this repo for which a PR is active, which is a bit of overkill.