### PR TITLE
Bump libicu versions to add support for Ubuntu 18.04

### DIFF
--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -83,7 +83,7 @@
       <DebDotNetDependencies Include="libunwind8"/>
       <DebDotNetDependencies Include="libuuid1"/>
       <DebDotNetDependencies Include="zlib1g"/>
-      <DebDotNetDependencies Include="libicu52 | libicu53 | libicu54 | libicu55 | libicu56 | libicu57 | libicu58 | libicu59"/>
+      <DebDotNetDependencies Include="libicu52 | libicu53 | libicu54 | libicu55 | libicu56 | libicu57 | libicu58 | libicu59 | libicu60 | libicu61 | libicu62 | libicu63"/>
     </ItemGroup>
     
     <DebTask PublishDir="$(PublishDir)" 


### PR DESCRIPTION
Ubuntu 18.04 ships with libicu60, so let's bump the version numbers a bit.