### PR TITLE
Add deployment unit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ script:
 
   - cd $TRAVIS_BUILD_DIR/demo/aspnetcore
   - dotnet restore
-  - if [ "$RUNTIME" = "rhel.7-x64" ]; then dotnet rpm -c Release -r rhel.7-x64 -f netcoreapp2.0; fi
-  - if [ "$RUNTIME" = "ubuntu.16.04-x64" ]; then dotnet deb -c Release -r ubuntu.16.04-x64 -f netcoreapp2.0; fi
+  - if [ "$RUNTIME" = "rhel.7-x64" ]; then dotnet rpm -c Release -r rhel.7-x64 -f netcoreapp2.1; fi
+  - if [ "$RUNTIME" = "ubuntu.16.04-x64" ]; then dotnet deb -c Release -r ubuntu.16.04-x64 -f netcoreapp2.1; fi
 
   - cd $TRAVIS_BUILD_DIR/demo/cliscd/
   - dotnet restore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,8 @@ test_script:
 
   - cmd: cd %APPVEYOR_BUILD_FOLDER%/demo/aspnetcore
   - cmd: dotnet restore
-  - cmd: dotnet rpm -c Release -r rhel.7-x64 -f netcoreapp2.0
-  - cmd: dotnet deb -c Release -r ubuntu.16.04-x64 -f netcoreapp2.0
+  - cmd: dotnet rpm -c Release -r rhel.7-x64 -f netcoreapp2.1
+  - cmd: dotnet deb -c Release -r ubuntu.16.04-x64 -f netcoreapp2.1
 
 artifacts:
   - path: dotnet-tarball\bin\Release\dotnet-tarball.*.nupkg

--- a/demo/aspnetcore/demo.csproj
+++ b/demo/aspnetcore/demo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeIdentifiers>win7-x64;rhel.7-x64;ubuntu.16.04-x64</RuntimeIdentifiers>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <CreateUser>true</CreateUser>
@@ -30,6 +30,6 @@
     <DotNetCliToolReference Include="dotnet-deb" Version="$(PackagingNuGetVersion)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.3" />
   </ItemGroup>
 </Project>

--- a/demo/cliscd/Program.cs
+++ b/demo/cliscd/Program.cs
@@ -21,21 +21,28 @@ namespace CliScd
             string testAssembly = typeof(Program).Assembly.Location;
             var typeName = args.Length == 2 ? args[1] : null;
 
-            using (var runner = AssemblyRunner.WithoutAppDomain(testAssembly))
+            try
             {
-                runner.OnDiscoveryComplete = OnDiscoveryComplete;
-                runner.OnExecutionComplete = OnExecutionComplete;
-                runner.OnTestFailed = OnTestFailed;
-                runner.OnTestSkipped = OnTestSkipped;
+                using (var runner = AssemblyRunner.WithoutAppDomain(testAssembly))
+                {
+                    runner.OnDiscoveryComplete = OnDiscoveryComplete;
+                    runner.OnExecutionComplete = OnExecutionComplete;
+                    runner.OnTestFailed = OnTestFailed;
+                    runner.OnTestSkipped = OnTestSkipped;
 
-                Console.WriteLine("Discovering...");
-                runner.Start(typeName);
+                    Console.WriteLine("Discovering...");
+                    runner.Start(typeName);
 
-                finished.WaitOne();
-                finished.Dispose();
-
-                return result;
+                    finished.WaitOne();
+                    finished.Dispose();
+                }
             }
+            catch (InvalidOperationException)
+            {
+                // Swallow
+            }
+
+            return result;
         }
 
         static void OnDiscoveryComplete(DiscoveryCompleteInfo info)

--- a/demo/cliscd/Program.cs
+++ b/demo/cliscd/Program.cs
@@ -1,12 +1,81 @@
 ﻿using System;
+using System.Threading;
+using Xunit.Runners;
 
 namespace CliScd
 {
     class Program
     {
-        static void Main(string[] args)
+        // We use consoleLock because messages can arrive in parallel, so we want to make sure we get
+        // consistent console output.
+        static object consoleLock = new object();
+
+        // Use an event to know when we're done
+        static ManualResetEvent finished = new ManualResetEvent(false);
+
+        // Start out assuming success; we'll set this to 1 if we get a failed test
+        static int result = 0;
+
+        static int Main(string[] args)
         {
-            Console.WriteLine("Hello World!");
+            string testAssembly = typeof(Program).Assembly.Location;
+            var typeName = args.Length == 2 ? args[1] : null;
+
+            using (var runner = AssemblyRunner.WithoutAppDomain(testAssembly))
+            {
+                runner.OnDiscoveryComplete = OnDiscoveryComplete;
+                runner.OnExecutionComplete = OnExecutionComplete;
+                runner.OnTestFailed = OnTestFailed;
+                runner.OnTestSkipped = OnTestSkipped;
+
+                Console.WriteLine("Discovering...");
+                runner.Start(typeName);
+
+                finished.WaitOne();
+                finished.Dispose();
+
+                return result;
+            }
+        }
+
+        static void OnDiscoveryComplete(DiscoveryCompleteInfo info)
+        {
+            lock (consoleLock)
+                Console.WriteLine($"Running {info.TestCasesToRun} of {info.TestCasesDiscovered} tests...");
+        }
+
+        static void OnExecutionComplete(ExecutionCompleteInfo info)
+        {
+            lock (consoleLock)
+                Console.WriteLine($"Finished: {info.TotalTests} tests in {Math.Round(info.ExecutionTime, 3)}s ({info.TestsFailed} failed, {info.TestsSkipped} skipped)");
+
+            finished.Set();
+        }
+
+        static void OnTestFailed(TestFailedInfo info)
+        {
+            lock (consoleLock)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+
+                Console.WriteLine("[FAIL] {0}: {1}", info.TestDisplayName, info.ExceptionMessage);
+                if (info.ExceptionStackTrace != null)
+                    Console.WriteLine(info.ExceptionStackTrace);
+
+                Console.ResetColor();
+            }
+
+            result = 1;
+        }
+
+        static void OnTestSkipped(TestSkippedInfo info)
+        {
+            lock (consoleLock)
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine("[SKIP] {0}: {1}", info.TestDisplayName, info.SkipReason);
+                Console.ResetColor();
+            }
         }
     }
 }

--- a/demo/cliscd/Tests.cs
+++ b/demo/cliscd/Tests.cs
@@ -19,7 +19,7 @@ namespace cliscd
         [Fact]
         public void MachineFileExists()
         {
-            Assert.True(File.Exists("/etc/clifdd/cliscd.machine.config"));
+            Assert.True(File.Exists("/etc/quamotion/cliscd.machine.config"));
         }
 
         [Fact]
@@ -32,6 +32,7 @@ namespace cliscd
         [InlineData("/var/log/quamotion")]
         [InlineData("/var/run/quamotion")]
         [InlineData("/var/lib/quamotion")]
+        [InlineData("/etc/quamotion")]
         public void LinuxFolderExists(string path)
         {
             Assert.True(Directory.Exists(path));

--- a/demo/cliscd/Tests.cs
+++ b/demo/cliscd/Tests.cs
@@ -1,0 +1,44 @@
+﻿using Mono.Unix;
+using System.IO;
+using Xunit;
+
+namespace cliscd
+{
+    public class Tests
+    {
+        [Fact]
+        public void UserExists()
+        {
+            var user = new UnixUserInfo("quamotion");
+            Assert.NotEqual(0, user.UserId);
+            Assert.NotEqual(0, user.GroupId);
+            Assert.Equal("quamotion", user.GroupName);
+            Assert.Equal("/usr/share/cliscd", user.HomeDirectory);
+        }
+
+        [Fact]
+        public void MachineFileExists()
+        {
+            Assert.True(File.Exists("/etc/clifdd/cliscd.machine.config"));
+        }
+
+        [Fact]
+        public void UserFileExists()
+        {
+            Assert.True(File.Exists("/home/quamotion/.cliscd/cliscd.user.config"));
+        }
+
+        [Theory]
+        [InlineData("/var/log/quamotion")]
+        [InlineData("/var/run/quamotion")]
+        [InlineData("/var/lib/quamotion")]
+        public void LinuxFolderExists(string path)
+        {
+            Assert.True(Directory.Exists(path));
+
+            var directoryInfo = new UnixDirectoryInfo(path);
+            Assert.Equal("quamotion", directoryInfo.OwnerGroup.GroupName);
+            Assert.Equal("quamotion", directoryInfo.OwnerUser.UserName);
+        }
+    }
+}

--- a/demo/cliscd/centos.7-x64/reference.txt
+++ b/demo/cliscd/centos.7-x64/reference.txt
@@ -4,6 +4,7 @@ Microsoft.CSharp.dll
 Microsoft.VisualBasic.dll
 Microsoft.Win32.Primitives.dll
 Microsoft.Win32.Registry.dll
+Mono.Posix.NETStandard.dll
 SOS.NETCore.dll
 System.AppContext.dll
 System.Buffers.dll
@@ -171,6 +172,7 @@ cliscd.dll
 cliscd.pdb
 cliscd.runtimeconfig.json
 createdump
+libMonoPosixHelper.so
 libclrjit.so
 libcoreclr.so
 libcoreclrtraceptprovider.so
@@ -184,5 +186,10 @@ libsosplugin.so
 mscorlib.dll
 netstandard.dll
 sosdocsunix.txt
+xunit.abstractions.dll
+xunit.assert.dll
+xunit.core.dll
+xunit.execution.dotnet.dll
+xunit.runner.utility.netcoreapp10.dll
 ls: cannot access /etc/cliscd: No such file or directory
 ls: cannot access /root/.cliscd: No such file or directory

--- a/demo/cliscd/cliscd.csproj
+++ b/demo/cliscd/cliscd.csproj
@@ -18,16 +18,15 @@
     <LinuxFolder Include="/var/log/quamotion" Group="quamotion" Owner="quamotion" RemoveOnUninstall="true" />
     <LinuxFolder Include="/var/run/quamotion" Group="quamotion" Owner="quamotion" RemoveOnUninstall="true" />
     <LinuxFolder Include="/var/lib/quamotion" Group="quamotion" Owner="quamotion" RemoveOnUninstall="true" />
+    <LinuxFolder Include="/etc/quamotion" Group="quamotion" Owner="quamotion" RemoveOnUninstall="true" />
   </ItemGroup>
   
   <ItemGroup>
-    <Content Include="cliscd.machine.config">
-      <LinuxPath>/etc/clifdd/cliscd.machine.config</LinuxPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    <Content Include="cliscd.machine.config" CopyToPublishDirectory="PreserveNewest">
+      <LinuxPath>/etc/quamotion/cliscd.machine.config</LinuxPath>
     </Content>
-    <Content Include="cliscd.user.config">
+    <Content Include="cliscd.user.config" CopyToPublishDirectory="PreserveNewest">
       <LinuxPath>/home/quamotion/.cliscd/cliscd.user.config</LinuxPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="readme.txt">
       <Documentation>true</Documentation>

--- a/demo/cliscd/cliscd.csproj
+++ b/demo/cliscd/cliscd.csproj
@@ -1,19 +1,32 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x64;win7-x86;win10-x64;win10-x86;osx-x64;debian.8-x64;debian.9-x64;ubuntu.18.04-x64;ubuntu.16.04-x64;ubuntu.14.04-x64;opensuse.42.3-x64;ol.7-x64;rhel-x64;fedora.27-x64;fedora.28-x64;centos.7-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win10-x64;osx-x64;debian.8-x64;debian.9-x64;ubuntu.18.04-x64;ubuntu.16.04-x64;ubuntu.14.04-x64;opensuse.42.3-x64;ol.7-x64;rhel-x64;fedora.27-x64;fedora.28-x64;centos.7-x64</RuntimeIdentifiers>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Create a Linux user named 'quamotion' -->
+    <CreateUser>true</CreateUser>
+    <UserName>quamotion</UserName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Create a couple of folders we may user -->
+    <LinuxFolder Include="/var/log/quamotion" Group="quamotion" Owner="quamotion" RemoveOnUninstall="true" />
+    <LinuxFolder Include="/var/run/quamotion" Group="quamotion" Owner="quamotion" RemoveOnUninstall="true" />
+    <LinuxFolder Include="/var/lib/quamotion" Group="quamotion" Owner="quamotion" RemoveOnUninstall="true" />
+  </ItemGroup>
+  
   <ItemGroup>
     <Content Include="cliscd.machine.config">
-      <LinuxFolder>/etc/clifdd</LinuxFolder>
+      <LinuxPath>/etc/clifdd/cliscd.machine.config</LinuxPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="cliscd.user.config">
-      <LinuxFolder>~/.clifdd</LinuxFolder>
+      <LinuxPath>/home/quamotion/.cliscd/cliscd.user.config</LinuxPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="readme.txt">
@@ -23,6 +36,9 @@
 
   <ItemGroup>
     <PackageReference Include="Packaging.Targets" Version="$(PackagingNuGetVersion)" />
+    <PackageReference Include="xunit.runner.utility" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <DotNetCliToolReference Include="dotnet-rpm" Version="$(PackagingNuGetVersion)" />
     <DotNetCliToolReference Include="dotnet-deb" Version="$(PackagingNuGetVersion)" />
   </ItemGroup>

--- a/demo/cliscd/cliscd.machine.config
+++ b/demo/cliscd/cliscd.machine.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+</configuration>

--- a/demo/cliscd/cliscd.user.config
+++ b/demo/cliscd/cliscd.user.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+</configuration>

--- a/demo/cliscd/debian.8-x64/reference.txt
+++ b/demo/cliscd/debian.8-x64/reference.txt
@@ -4,6 +4,7 @@ Microsoft.CSharp.dll
 Microsoft.VisualBasic.dll
 Microsoft.Win32.Primitives.dll
 Microsoft.Win32.Registry.dll
+Mono.Posix.NETStandard.dll
 SOS.NETCore.dll
 System.AppContext.dll
 System.Buffers.dll
@@ -171,6 +172,7 @@ cliscd.dll
 cliscd.pdb
 cliscd.runtimeconfig.json
 createdump
+libMonoPosixHelper.so
 libclrjit.so
 libcoreclr.so
 libcoreclrtraceptprovider.so
@@ -184,5 +186,10 @@ libsosplugin.so
 mscorlib.dll
 netstandard.dll
 sosdocsunix.txt
+xunit.abstractions.dll
+xunit.assert.dll
+xunit.core.dll
+xunit.execution.dotnet.dll
+xunit.runner.utility.netcoreapp10.dll
 ls: cannot access /etc/cliscd: No such file or directory
 ls: cannot access /root/.cliscd: No such file or directory

--- a/demo/cliscd/debian.9-x64/reference.txt
+++ b/demo/cliscd/debian.9-x64/reference.txt
@@ -4,6 +4,7 @@ Microsoft.CSharp.dll
 Microsoft.VisualBasic.dll
 Microsoft.Win32.Primitives.dll
 Microsoft.Win32.Registry.dll
+Mono.Posix.NETStandard.dll
 SOS.NETCore.dll
 System.AppContext.dll
 System.Buffers.dll
@@ -171,6 +172,7 @@ cliscd.dll
 cliscd.pdb
 cliscd.runtimeconfig.json
 createdump
+libMonoPosixHelper.so
 libclrjit.so
 libcoreclr.so
 libcoreclrtraceptprovider.so
@@ -184,5 +186,10 @@ libsosplugin.so
 mscorlib.dll
 netstandard.dll
 sosdocsunix.txt
+xunit.abstractions.dll
+xunit.assert.dll
+xunit.core.dll
+xunit.execution.dotnet.dll
+xunit.runner.utility.netcoreapp10.dll
 ls: cannot access '/etc/cliscd': No such file or directory
 ls: cannot access '/root/.cliscd': No such file or directory

--- a/demo/cliscd/fedora.27-x64/reference.txt
+++ b/demo/cliscd/fedora.27-x64/reference.txt
@@ -4,6 +4,7 @@ Microsoft.CSharp.dll
 Microsoft.VisualBasic.dll
 Microsoft.Win32.Primitives.dll
 Microsoft.Win32.Registry.dll
+Mono.Posix.NETStandard.dll
 SOS.NETCore.dll
 System.AppContext.dll
 System.Buffers.dll
@@ -171,6 +172,7 @@ cliscd.dll
 cliscd.pdb
 cliscd.runtimeconfig.json
 createdump
+libMonoPosixHelper.so
 libclrjit.so
 libcoreclr.so
 libcoreclrtraceptprovider.so
@@ -184,5 +186,10 @@ libsosplugin.so
 mscorlib.dll
 netstandard.dll
 sosdocsunix.txt
+xunit.abstractions.dll
+xunit.assert.dll
+xunit.core.dll
+xunit.execution.dotnet.dll
+xunit.runner.utility.netcoreapp10.dll
 ls: cannot access '/etc/cliscd': No such file or directory
 ls: cannot access '/root/.cliscd': No such file or directory

--- a/demo/cliscd/fedora.28-x64/reference.txt
+++ b/demo/cliscd/fedora.28-x64/reference.txt
@@ -4,6 +4,7 @@ Microsoft.CSharp.dll
 Microsoft.VisualBasic.dll
 Microsoft.Win32.Primitives.dll
 Microsoft.Win32.Registry.dll
+Mono.Posix.NETStandard.dll
 SOS.NETCore.dll
 System.AppContext.dll
 System.Buffers.dll
@@ -171,6 +172,7 @@ cliscd.dll
 cliscd.pdb
 cliscd.runtimeconfig.json
 createdump
+libMonoPosixHelper.so
 libclrjit.so
 libcoreclr.so
 libcoreclrtraceptprovider.so
@@ -184,5 +186,10 @@ libsosplugin.so
 mscorlib.dll
 netstandard.dll
 sosdocsunix.txt
+xunit.abstractions.dll
+xunit.assert.dll
+xunit.core.dll
+xunit.execution.dotnet.dll
+xunit.runner.utility.netcoreapp10.dll
 ls: cannot access '/etc/cliscd': No such file or directory
 ls: cannot access '/root/.cliscd': No such file or directory

--- a/demo/cliscd/ol.7-x64/reference.txt
+++ b/demo/cliscd/ol.7-x64/reference.txt
@@ -4,6 +4,7 @@ Microsoft.CSharp.dll
 Microsoft.VisualBasic.dll
 Microsoft.Win32.Primitives.dll
 Microsoft.Win32.Registry.dll
+Mono.Posix.NETStandard.dll
 SOS.NETCore.dll
 System.AppContext.dll
 System.Buffers.dll
@@ -171,6 +172,7 @@ cliscd.dll
 cliscd.pdb
 cliscd.runtimeconfig.json
 createdump
+libMonoPosixHelper.so
 libclrjit.so
 libcoreclr.so
 libcoreclrtraceptprovider.so
@@ -184,5 +186,10 @@ libsosplugin.so
 mscorlib.dll
 netstandard.dll
 sosdocsunix.txt
+xunit.abstractions.dll
+xunit.assert.dll
+xunit.core.dll
+xunit.execution.dotnet.dll
+xunit.runner.utility.netcoreapp10.dll
 ls: cannot access /etc/cliscd: No such file or directory
 ls: cannot access /root/.cliscd: No such file or directory

--- a/demo/cliscd/opensuse.42.3-x64/reference.txt
+++ b/demo/cliscd/opensuse.42.3-x64/reference.txt
@@ -4,6 +4,7 @@ Microsoft.CSharp.dll
 Microsoft.VisualBasic.dll
 Microsoft.Win32.Primitives.dll
 Microsoft.Win32.Registry.dll
+Mono.Posix.NETStandard.dll
 SOS.NETCore.dll
 System.AppContext.dll
 System.Buffers.dll
@@ -171,6 +172,7 @@ cliscd.dll
 cliscd.pdb
 cliscd.runtimeconfig.json
 createdump
+libMonoPosixHelper.so
 libclrjit.so
 libcoreclr.so
 libcoreclrtraceptprovider.so
@@ -184,5 +186,10 @@ libsosplugin.so
 mscorlib.dll
 netstandard.dll
 sosdocsunix.txt
+xunit.abstractions.dll
+xunit.assert.dll
+xunit.core.dll
+xunit.execution.dotnet.dll
+xunit.runner.utility.netcoreapp10.dll
 ls: cannot access '/etc/cliscd': No such file or directory
 ls: cannot access '/root/.cliscd': No such file or directory

--- a/demo/cliscd/ubuntu.14.04-x64/reference.txt
+++ b/demo/cliscd/ubuntu.14.04-x64/reference.txt
@@ -4,6 +4,7 @@ Microsoft.CSharp.dll
 Microsoft.VisualBasic.dll
 Microsoft.Win32.Primitives.dll
 Microsoft.Win32.Registry.dll
+Mono.Posix.NETStandard.dll
 SOS.NETCore.dll
 System.AppContext.dll
 System.Buffers.dll
@@ -171,6 +172,7 @@ cliscd.dll
 cliscd.pdb
 cliscd.runtimeconfig.json
 createdump
+libMonoPosixHelper.so
 libclrjit.so
 libcoreclr.so
 libcoreclrtraceptprovider.so
@@ -184,5 +186,10 @@ libsosplugin.so
 mscorlib.dll
 netstandard.dll
 sosdocsunix.txt
+xunit.abstractions.dll
+xunit.assert.dll
+xunit.core.dll
+xunit.execution.dotnet.dll
+xunit.runner.utility.netcoreapp10.dll
 ls: cannot access /etc/cliscd: No such file or directory
 ls: cannot access /root/.cliscd: No such file or directory

--- a/demo/cliscd/ubuntu.16.04-x64/reference.txt
+++ b/demo/cliscd/ubuntu.16.04-x64/reference.txt
@@ -4,6 +4,7 @@ Microsoft.CSharp.dll
 Microsoft.VisualBasic.dll
 Microsoft.Win32.Primitives.dll
 Microsoft.Win32.Registry.dll
+Mono.Posix.NETStandard.dll
 SOS.NETCore.dll
 System.AppContext.dll
 System.Buffers.dll
@@ -171,6 +172,7 @@ cliscd.dll
 cliscd.pdb
 cliscd.runtimeconfig.json
 createdump
+libMonoPosixHelper.so
 libclrjit.so
 libcoreclr.so
 libcoreclrtraceptprovider.so
@@ -184,5 +186,10 @@ libsosplugin.so
 mscorlib.dll
 netstandard.dll
 sosdocsunix.txt
+xunit.abstractions.dll
+xunit.assert.dll
+xunit.core.dll
+xunit.execution.dotnet.dll
+xunit.runner.utility.netcoreapp10.dll
 ls: cannot access '/etc/cliscd': No such file or directory
 ls: cannot access '/root/.cliscd': No such file or directory

--- a/demo/cliscd/ubuntu.18.04-x64/reference.txt
+++ b/demo/cliscd/ubuntu.18.04-x64/reference.txt
@@ -4,6 +4,7 @@ Microsoft.CSharp.dll
 Microsoft.VisualBasic.dll
 Microsoft.Win32.Primitives.dll
 Microsoft.Win32.Registry.dll
+Mono.Posix.NETStandard.dll
 SOS.NETCore.dll
 System.AppContext.dll
 System.Buffers.dll
@@ -171,6 +172,7 @@ cliscd.dll
 cliscd.pdb
 cliscd.runtimeconfig.json
 createdump
+libMonoPosixHelper.so
 libclrjit.so
 libcoreclr.so
 libcoreclrtraceptprovider.so
@@ -184,5 +186,10 @@ libsosplugin.so
 mscorlib.dll
 netstandard.dll
 sosdocsunix.txt
+xunit.abstractions.dll
+xunit.assert.dll
+xunit.core.dll
+xunit.execution.dotnet.dll
+xunit.runner.utility.netcoreapp10.dll
 ls: cannot access '/etc/cliscd': No such file or directory
 ls: cannot access '/root/.cliscd': No such file or directory


### PR DESCRIPTION
This PR updates the `cliscd` app so that it runs xUnit tests when the app starts.

These tests are used to verify the app has been installed/deployed correct. This includes:
- Testing the Linux user which should have been created
- Testing the files which should have been deployed to non-standard locations
