### PR TITLE
Fix path to /usr/bin/rm

### DIFF
--- a/Packaging.Targets.Tests/Deb/DebPackageCreatorTests.cs
+++ b/Packaging.Targets.Tests/Deb/DebPackageCreatorTests.cs
@@ -139,8 +139,8 @@ echo 'Hello from post install'
             Assert.Equal(@"systemctl --no-reload disable --now demoservice.service
 echo 'Hello from pre remove'
 ", pkg.PreRemoveScript, ignoreLineEndingDifferences: true);
-            Assert.Equal(@"/usr/bin/rm -rf /usr/bin/demo
-/usr/bin/rm -rf /opt/local/test
+            Assert.Equal(@"/bin/rm -rf /usr/bin/demo
+/bin/rm -rf /opt/local/test
 echo 'Hello from post remove'
 ", pkg.PostRemoveScript, ignoreLineEndingDifferences: true);
         }

--- a/Packaging.Targets/Deb/DebPackageCreator.cs
+++ b/Packaging.Targets/Deb/DebPackageCreator.cs
@@ -87,7 +87,7 @@ namespace Packaging.Targets.Deb
             // Remove all directories marked as such (these are usually directories which contain temporary files)
             foreach (var entryToRemove in archiveEntries.Where(e => e.RemoveOnUninstall))
             {
-                pkg.PostRemoveScript += $"/usr/bin/rm -rf {entryToRemove.TargetPath}\n";
+                pkg.PostRemoveScript += $"/bin/rm -rf {entryToRemove.TargetPath}\n";
             }
 
             if (!string.IsNullOrEmpty(preInstallScript))

--- a/demo/cliscd/run-tests.sh
+++ b/demo/cliscd/run-tests.sh
@@ -42,3 +42,18 @@ dotnet $format -c Release -r $rid -f netcoreapp2.1
 cp bin/Release/netcoreapp2.1/$rid/cliscd.1.0.0.$rid.$format $rid
 sudo docker build -t clisc:$rid $rid
 sudo docker run clisc:$rid
+
+if [[ $format == deb ]]
+then
+    sudo docker run clisc:$rid /usr/bin/apt-get remove -y cliscd
+fi
+
+if [[ $format == rpm ]]
+then
+    if [[ $rid == opensuse* ]]
+    then
+        sudo docker run clisc:$rid /usr/bin/zypper -n rm cliscd
+    else
+        sudo docker run clisc:$rid /usr/bin/rpm -e cliscd
+    fi
+fi


### PR DESCRIPTION
At least on Ubuntu 18.04, /usr/bin/rm doesn't exist - but /bin/rm does. The /usr/bin copy comes from the safe-rm package. We could just declare a dependency on this package, but this is in universe and this repo is not enabled by default.

Fixes #55 