### PR TITLE
Fill RPM and DEB Vendor, Description and URL

### DIFF
--- a/Packaging.Targets.Tests/Rpm/PlistMetadata.cs
+++ b/Packaging.Targets.Tests/Rpm/PlistMetadata.cs
@@ -18,7 +18,6 @@ namespace Packaging.Targets.Tests.Rpm
             metadata.BuildHost = "lamb11";
             metadata.BuildTime = new DateTimeOffset(2017, 04, 21, 20, 56, 28, TimeSpan.Zero);
             metadata.Cookie = "lamb11 1492808188";
-            metadata.Description = "libplist is a library for manipulating Apple Binary and XML Property Lists";
             metadata.Distribution = "home:qmfrederik / CentOS_7";
             metadata.DistUrl = "obs://build.opensuse.org/home:qmfrederik/CentOS_7/adfeea138cd469466e6fa13a3c88fb8f-libplist";
             metadata.FileDigetsAlgo = PgpHashAlgo.PGPHASHALGO_SHA256;
@@ -36,8 +35,6 @@ namespace Packaging.Targets.Tests.Rpm
             metadata.SourcePkgId = new byte[] { 0x45, 0xc0, 0x86, 0x80, 0x77, 0x4e, 0xf4, 0xc0, 0x37, 0xf1, 0x1e, 0xb1, 0xd3, 0x47, 0xf0, 0xbf };
             metadata.SourceRpm = "libplist-2.0.1.151-1.1.src.rpm";
             metadata.Summary = "Library for manipulating Apple Binary and XML Property Lists";
-            metadata.Url = "http://www.libimobiledevice.org/";
-            metadata.Vendor = "obs://build.opensuse.org/home:qmfrederik";
             CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
             Collection<ChangelogEntry> changeLogEntries = new Collection<ChangelogEntry>()
                     {

--- a/Packaging.Targets.Tests/Rpm/RpmMetadataTests.cs
+++ b/Packaging.Targets.Tests/Rpm/RpmMetadataTests.cs
@@ -205,6 +205,9 @@ namespace Packaging.Targets.Tests.Rpm
 
                     PlistMetadata.ApplyDefaultMetadata(metadata);
 
+                    metadata.Vendor = "obs://build.opensuse.org/home:qmfrederik";
+                    metadata.Description = "libplist is a library for manipulating Apple Binary and XML Property Lists";
+                    metadata.Url = "http://www.libimobiledevice.org/";
                     metadata.Size = 0x26e6d;
                     metadata.ImmutableRegionSize = -976;
 

--- a/Packaging.Targets.Tests/Rpm/RpmPackageCreatorTests.cs
+++ b/Packaging.Targets.Tests/Rpm/RpmPackageCreatorTests.cs
@@ -117,6 +117,9 @@ namespace Packaging.Targets.Tests.Rpm
 
                     PlistMetadata.ApplyDefaultMetadata(metadata);
 
+                    metadata.Vendor = "obs://build.opensuse.org/home:qmfrederik";
+                    metadata.Description = "libplist is a library for manipulating Apple Binary and XML Property Lists";
+                    metadata.Url = "http://www.libimobiledevice.org/";
                     metadata.Size = 0x26e6d;
                     metadata.ImmutableRegionSize = -976;
 
@@ -170,6 +173,10 @@ namespace Packaging.Targets.Tests.Rpm
                 creator.AddRpmDependencies(metadata, null);
 
                 PlistMetadata.ApplyDefaultMetadata(metadata);
+
+                metadata.Vendor = "obs://build.opensuse.org/home:qmfrederik";
+                metadata.Description = "libplist is a library for manipulating Apple Binary and XML Property Lists";
+                metadata.Url = "http://www.libimobiledevice.org/";
 
                 creator.CalculateHeaderOffsets(package);
 
@@ -282,6 +289,9 @@ namespace Packaging.Targets.Tests.Rpm
                         null,
                         false,
                         null,
+                        "obs://build.opensuse.org/home:qmfrederik",
+                        "libplist is a library for manipulating Apple Binary and XML Property Lists",
+                        "http://www.libimobiledevice.org/",
                         null,
                         preInstScript,
                         postInstScript,
@@ -355,6 +365,9 @@ namespace Packaging.Targets.Tests.Rpm
                         null,
                         false,
                         null,
+                        "obs://build.opensuse.org/home:qmfrederik",
+                        "libplist is a library for manipulating Apple Binary and XML Property Lists",
+                        "http://www.libimobiledevice.org/",
                         null,
                         null,
                         null,

--- a/Packaging.Targets/Rpm/RpmPackageCreator.cs
+++ b/Packaging.Targets/Rpm/RpmPackageCreator.cs
@@ -81,6 +81,15 @@ namespace Packaging.Targets.Rpm
         /// <param name="serviceName">
         /// The name of the system service to create.
         /// </param>
+        /// <param name="vendor">
+        /// The package vendor.
+        /// </param>
+        /// <param name="description">
+        /// The package description.
+        /// </param>
+        /// <param name="url">
+        /// The package URL.
+        /// </param>
         /// <param name="prefix">
         /// A prefix to use.
         /// </param>
@@ -119,6 +128,9 @@ namespace Packaging.Targets.Rpm
             string userName,
             bool installService,
             string serviceName,
+            string vendor,
+            string description,
+            string url,
             string prefix,
             string preInstallScript,
             string postInstallScript,
@@ -140,6 +152,9 @@ namespace Packaging.Targets.Rpm
                 userName,
                 installService,
                 serviceName,
+                vendor,
+                description,
+                url,
                 prefix,
                 preInstallScript,
                 postInstallScript,
@@ -183,6 +198,15 @@ namespace Packaging.Targets.Rpm
         /// </param>
         /// <param name="serviceName">
         /// The name of the system service to create.
+        /// </param>
+        /// <param name="vendor">
+        /// The package vendor.
+        /// </param>
+        /// <param name="description">
+        /// The package description.
+        /// </param>
+        /// <param name="url">
+        /// The package URL.
         /// </param>
         /// <param name="prefix">
         /// A prefix to use.
@@ -232,6 +256,9 @@ namespace Packaging.Targets.Rpm
             string userName,
             bool installService,
             string serviceName,
+            string vendor,
+            string description,
+            string url,
             string prefix,
             string preInstallScript,
             string postInstallScript,
@@ -360,14 +387,16 @@ namespace Packaging.Targets.Rpm
             }
 
             // Not providing these (or setting empty values) would cause rpmlint errors
-            metadata.Description = $"{name} version {version}-{release}";
+            metadata.Description = string.IsNullOrEmpty(description)
+                ? $"{name} version {version}-{release}"
+                : description;
             metadata.Summary = $"{name} version {version}-{release}";
             metadata.License = $"{name} License";
 
             metadata.Distribution = string.Empty;
             metadata.DistUrl = string.Empty;
-            metadata.Url = string.Empty;
-            metadata.Vendor = string.Empty;
+            metadata.Url = url ?? string.Empty;
+            metadata.Vendor = vendor ?? string.Empty;
 
             metadata.ChangelogEntries = new Collection<ChangelogEntry>()
             {

--- a/Packaging.Targets/RpmTask.cs
+++ b/Packaging.Targets/RpmTask.cs
@@ -125,6 +125,33 @@ namespace Packaging.Targets
         }
 
         /// <summary>
+        /// Gets or sets the package vendor.
+        /// </summary>
+        public string Vendor
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the package description.
+        /// </summary>
+        public string Description
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the package URL.
+        /// </summary>
+        public string Url
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Gets or sets an additional pre-installation script to execute.
         /// </summary>
         /// <remarks>
@@ -214,6 +241,9 @@ namespace Packaging.Targets
                     this.UserName,
                     this.InstallService,
                     this.ServiceName,
+                    this.Vendor,
+                    this.Description,
+                    this.Url,
                     this.Prefix,
                     this.PreInstallScript,
                     this.PostInstallScript,

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -19,7 +19,8 @@
       <CreateUser Condition="'$(CreateUser)' == ''">false</CreateUser>
       <InstallService Condition="'$(InstallService)' == ''">false</InstallService>
       <PackageMaintainer Condition="'$(PackageMaintainer)' == ''">Anonymous &lt;noreply@example.com&gt;</PackageMaintainer>
-      <PackageDescription Condition="'$(PackageDescription)' == ''">$(PackageName)</PackageDescription>
+      <PackageDescription Condition="'$(PackageDescription)' == '' AND '$(Description)' != ''">$(Description)</PackageDescription>
+      <PackageDescription Condition="'$(PackageDescription)' == '' AND '$(Description)' == ''">$(PackageName) version $(PackageVersion) - $(Release)</PackageDescription>
     </PropertyGroup>
   </Target>
 

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -18,7 +18,8 @@
       <PackagePath Condition="'$(PackagePath)' == ''">$(TargetDir)$(PackageName)</PackagePath>
       <CreateUser Condition="'$(CreateUser)' == ''">false</CreateUser>
       <InstallService Condition="'$(InstallService)' == ''">false</InstallService>
-      <PackageMaintainer Condition="'$(PackageMaintainer)' == ''">Anonymous &lt;noreply@example.com&gt;</PackageMaintainer>
+      <PackageMaintainer Condition="'$(PackageMaintainer)' == '' AND '$(Authors)' != ''">$(Authors)</PackageMaintainer>
+      <PackageMaintainer Condition="'$(PackageMaintainer)' == '' AND '$(Authors)' == ''">Anonymous &lt;noreply@example.com&gt;</PackageMaintainer>
       <PackageDescription Condition="'$(PackageDescription)' == '' AND '$(Description)' != ''">$(Description)</PackageDescription>
       <PackageDescription Condition="'$(PackageDescription)' == '' AND '$(Description)' == ''">$(PackageName) version $(PackageVersion) - $(Release)</PackageDescription>
     </PropertyGroup>

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -31,8 +31,11 @@
       <Release Condition="'$(Release)' == ''">0</Release>
       <PackageName>$(PackagePrefix)</PackageName>
       <UserName Condition="'$(UserName)' == ''">$(PackagePrefix)</UserName>
-      <ServiceName Condition="'$(ServiceName)' == ''">$(PackagePrefix)</ServiceName >
-    </PropertyGroup>
+      <ServiceName Condition="'$(ServiceName)' == ''">$(PackagePrefix)</ServiceName>
+      <RpmVendor Condition="'$(RpmVendor)' == ''">$(Authors)</RpmVendor>
+      <RpmDescription Condition="'$(RpmDescription)' == ''">$(PackageDescription)</RpmDescription>
+      <RpmUrl Condition="'$(RpmUrl)' == ''">$(PackageProjectUrl)</RpmUrl>
+  </PropertyGroup>
 
     <Message Text="Creating RPM package $(RpmPath)" Importance="high"/>
 
@@ -50,6 +53,9 @@
              UserName="$(UserName)"
              InstallService="$(InstallService)"
              ServiceName="$(ServiceName)"
+             Vendor="$(RpmVendor)"
+             Description="$(RpmDescription)"
+             Url="$(RpmUrl)"
              PreInstallScript="$(PreInstallScript)"
              PostInstallScript="$(PostInstallScript)"
              PreRemoveScript="$(PreRemoveScript)"


### PR DESCRIPTION
See [this](https://github.com/qmfrederik/dotnet-packaging/issues/91) issue.
Added 3 corresponding properties for `RpmTask`. Also amended .targets file for `DebTask` to take `Authors` MSBuild property as a default for `PackageMaintainer` and `Description` - for `PackageDescription`. The last should be useful, because Visual Studio UI fills `Description` property by default - see https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#description.