### PR TITLE
Add command option to set package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All commands take the following command line arguments:
 * `-r`, `--runtime`: Required. The target runtime has to be specified in the project file. For example, `win7-x64` or `ubuntu.16.10-x64`.
 * `-f`, `--framework`: Required. The target framework has to be specified in the project file. For example, `netcoreapp1.1` or `net462`.
 * `-c`, `--configuration`: Target configuration. The default for most projects is 'Debug'.
-*  `---version-suffix`: Defines the value for the `$(VersionSuffix)` property in the project.
+* `-v`, `--version`: Defines the version of the package. The default is 1.0.0.
 
 
 ### Note

--- a/dotnet-rpm/PackagingRunner.cs
+++ b/dotnet-rpm/PackagingRunner.cs
@@ -35,9 +35,9 @@ namespace Dotnet.Packaging
               $"Required. Target configuration of the {outputName}. The default for most projects is 'Debug'.",
               CommandOptionType.SingleValue);
 
-            CommandOption versionSuffix = commandLineApplication.Option(
-              "---version-suffix <version-suffix>",
-              "Defines the value for the $(VersionSuffix) property in the project.",
+            CommandOption version = commandLineApplication.Option(
+              "-v | --version <version>",
+              "Defines the version of the package. The default is 1.0.0.",
               CommandOptionType.SingleValue);
 
             commandLineApplication.HelpOption("-? | -h | --help");
@@ -76,9 +76,9 @@ namespace Dotnet.Packaging
                     msbuildArguments.Append($"/p:Configuration={configuration.Value()} ");
                 }
 
-                if (versionSuffix.HasValue())
+                if (version.HasValue())
                 {
-                    msbuildArguments.Append($"/p:VersionSuffix={versionSuffix.Value()} ");
+                    msbuildArguments.Append($"/p:Version={version.Value()} ");
                 }
 
                 var psi = new ProcessStartInfo


### PR DESCRIPTION
I needed to set a custom version for my deb packages but nothing seemed to go right.

The `---version-suffix` command option sets the `$(VersionSuffix)` property in the project, however this property is not used anywhere, as opposed to `$(Version)` or `$(PackageVersion)`.

I was only able to set custom version for my deb packages by invoking the package tools manually and setting `/p:Version={version}` property.

This pull request changes the command option from `---version-suffix` to a simple `-v | --version` that sets the `$(Version)` property, the one actually used by `Packaging.Targets`.

