### PR TITLE
Bump SourceLink version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,18 @@
+<Project>
+  <PropertyGroup>
+    <Authors>Frederik Carlier</Authors>
+    <Company>Quamotion</Company>
+    <Copyright>Copyright (c) Frederik Carlier and Contributors</Copyright>
+    <RepositoryType>git</RepositoryType>
+    <Product>Packaging Tools for .NET CLI</Product>
+        
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NerdBank.GitVersioning" Version="2.3.3" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Authors>Frederik Carlier</Authors>
-    <Company>Quamotion</Company>
-    <Product>Packaging Tools for .NET CLI</Product>
     <Description>This package supports the dotnet-pack and dotnet-zip packages. Once you've installed this package together with dotnet-zip or dotnet-tarball, you can run commands such as dotnet zip or dotnet tarball to generate .zip or .tar.gz archives which contain the published output of your project.</Description>
-    <Copyright>Copyright (c) Frederik Carlier and Contributors</Copyright>
-    <RepositoryType>git</RepositoryType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.5|AnyCPU'">
@@ -44,8 +39,6 @@
     <PackageReference Include="SharpZipLib.NETStandard" Version="0.86.0.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NerdBank.GitVersioning" Version="3.0.25" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
     <PackageReference Include="System.Buffers" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/dotnet-deb/dotnet-deb.csproj
+++ b/dotnet-deb/dotnet-deb.csproj
@@ -2,30 +2,18 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <Authors>Frederik Carlier</Authors>
-    <Company>Quamotion</Company>
-    <Copyright>Copyright (c) Frederik Carlier and Contributors</Copyright>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>dotnet cli packaging deb debian ubuntu mint installer</PackageTags>
     <Description>Create Debian and Ubuntu installers (.deb files ) of your .NET Core projects straight from the command line.
 
 Once you've installed this package as a .NET CLI tool, run dotnet deb to generate a .deb file which contains the publish output of your .NET Project.
 
 See https://github.com/qmfrederik/dotnet-packaging/ for more information on how to use dotnet deb.</Description>
-    <Product>Packaging Tools for .NET CLI</Product>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-deb</ToolCommandName>
-    
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="NerdBank.GitVersioning" Version="3.0.25" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
   </ItemGroup>
   
   <ItemGroup>

--- a/dotnet-rpm/dotnet-rpm.csproj
+++ b/dotnet-rpm/dotnet-rpm.csproj
@@ -2,29 +2,17 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <Authors>Frederik Carlier</Authors>
-    <Company>Quamotion</Company>
-    <Copyright>Copyright (c) Frederik Carlier and Contributors</Copyright>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>dotnet cli packaging rpm package installer</PackageTags>
     <Description>Create RPM packages (.rpm files) of your .NET Core projects straight from the command line.
 
 Once you've installed this package as a .NET CLI tool, run dotnet rpm to generate a .rpm package which contains the publish output of your .NET Project.
 
 See https://github.com/qmfrederik/dotnet-packaging/ for more information on how to use dotnet rpm.</Description>
-    <Product>Packaging Tools for .NET CLI</Product>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-rpm</ToolCommandName>
-    
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="NerdBank.GitVersioning" Version="3.0.25" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/dotnet-tarball/dotnet-tarball.csproj
+++ b/dotnet-tarball/dotnet-tarball.csproj
@@ -2,30 +2,18 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <Authors>Frederik Carlier</Authors>
-    <Company>Quamotion</Company>
-    <Copyright>Copyright (c) Frederik Carlier and Contributors</Copyright>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>dotnet cli packaging tarball tar.gz archive</PackageTags>
     <Description>Create tarballs (.tar.gz files) of your .NET Core projects straight from the command line.
 
 Once you've installed this package as a .NET CLI tool, run dotnet tar to generate a .tar.gz file which contains the publish output of your .NET Project.
 
 See https://github.com/qmfrederik/dotnet-packaging/ for more information on how to use dotnet tarball.</Description>
-    <Product>Packaging Tools for .NET CLI</Product>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-tarball</ToolCommandName>
-    
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="NerdBank.GitVersioning" Version="3.0.25" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
   </ItemGroup>
   
   <ItemGroup>

--- a/dotnet-zip/dotnet-zip.csproj
+++ b/dotnet-zip/dotnet-zip.csproj
@@ -2,30 +2,18 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <Authors>Frederik Carlier</Authors>
-    <Company>Quamotion</Company>
-    <Copyright>Copyright (c) Frederik Carlier and Contributors</Copyright>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>dotnet cli packaging zip archive</PackageTags>
     <Description>Create .zip files of your .NET Core projects straight from the command line.
 
 Once you've installed this package as a .NET CLI tool, run dotnet zip to generate a .zip file which contains the publish output of your .NET Project.
 
 See https://github.com/qmfrederik/dotnet-packaging/ for more information on how to use dotnet tarball.</Description>
-    <Product>Packaging Tools for .NET CLI</Product>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-zip</ToolCommandName>
-    
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="NerdBank.GitVersioning" Version="3.0.25" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
It looks like using a new version of NerdBank.GitVersioning and using SourceLink cases the package version for Packaging.Targets to sometime miss the git qualifier.

This will case package restore to fail in subsequent steps.

Revert that change, and as a simplification, move a bunch of shared properties to Directory.Build.props