### PR TITLE
Support multiple package architectures

### DIFF
--- a/Packaging.Targets.Tests/Deb/DebTaskTests.cs
+++ b/Packaging.Targets.Tests/Deb/DebTaskTests.cs
@@ -1,0 +1,36 @@
+﻿using Xunit;
+
+namespace Packaging.Targets.Tests.Deb
+{
+    /// <summary>
+    /// Tests the <see cref="DebTask"/> class.
+    /// </summary>
+    public class DebTaskTests
+    {
+        /// <summary>
+        /// Tests the <see cref="DebTask.GetPackageArchitecture(string)"/> method.
+        /// </summary>
+        /// <param name="runtimeIdentifier">
+        /// The .NET runtime identifier.
+        /// </param>
+        /// <param name="packageAchitecture">
+        /// The expected package architecture.
+        /// </param>
+        [InlineData(null, "any")]
+        [InlineData("ubuntu.18.04", "any")]
+        [InlineData("ubuntu.18.04-x86", "i386")]
+        [InlineData("ubuntu.18.04-x64", "amd64")]
+        [InlineData("ubuntu.18.04-arm", "armhf")]
+        [InlineData("ubuntu.18.04-arm64", "arm64")]
+        [InlineData("linux", "any")]
+        [InlineData("linux-x86", "i386")]
+        [InlineData("linux-x64", "amd64")]
+        [InlineData("linux-arm", "armhf")]
+        [InlineData("linux-arm64", "arm64")]
+        [Theory]
+        public void GetPackageArchitectureTest(string runtimeIdentifier, string packageAchitecture)
+        {
+            Assert.Equal(packageAchitecture, DebTask.GetPackageArchitecture(runtimeIdentifier));
+        }
+    }
+}

--- a/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
+++ b/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Packaging.Targets.Tests/Rpm/RpmTaskTests.cs
+++ b/Packaging.Targets.Tests/Rpm/RpmTaskTests.cs
@@ -1,0 +1,36 @@
+﻿using Xunit;
+
+namespace Packaging.Targets.Tests.Rpm
+{
+    /// <summary>
+    /// Tests the <see cref="RpmTask"/> class.
+    /// </summary>
+    public class RpmTaskTests
+    {
+        /// <summary>
+        /// Tests the <see cref="DebTask.GetPackageArchitecture(string)"/> method.
+        /// </summary>
+        /// <param name="runtimeIdentifier">
+        /// The .NET runtime identifier.
+        /// </param>
+        /// <param name="packageAchitecture">
+        /// The expected package architecture.
+        /// </param>
+        [InlineData(null, "any")]
+        [InlineData("ubuntu.18.04", "any")]
+        [InlineData("ubuntu.18.04-x86", "i386")]
+        [InlineData("ubuntu.18.04-x64", "x86_64")]
+        [InlineData("ubuntu.18.04-arm", "armhfp")]
+        [InlineData("ubuntu.18.04-arm64", "aarch64")]
+        [InlineData("linux", "any")]
+        [InlineData("linux-x86", "i386")]
+        [InlineData("linux-x64", "x86_64")]
+        [InlineData("linux-arm", "armhfp")]
+        [InlineData("linux-arm64", "aarch64")]
+        [Theory]
+        public void GetPackageArchitectureTest(string runtimeIdentifier, string packageAchitecture)
+        {
+            Assert.Equal(packageAchitecture, RpmTask.GetPackageArchitecture(runtimeIdentifier));
+        }
+    }
+}

--- a/Packaging.Targets.Tests/RuntimeIdentifierTests.cs
+++ b/Packaging.Targets.Tests/RuntimeIdentifierTests.cs
@@ -1,0 +1,77 @@
+﻿using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Packaging.Targets.Tests
+{
+    public class RuntimeIdentifierTests
+    {
+        /// <summary>
+        /// Tests the <see cref="RuntimeIdentifiers.ParseRuntimeId(string, out string, out string, out Architecture?, out string)"/> method.
+        /// </summary>
+        /// <param name="rid">
+        /// The runtime identifier to parse.
+        /// </param>
+        /// <param name="expectedOsName">
+        /// The expected operating system name.
+        /// </param>
+        /// <param name="expectedVersion">
+        /// The expected operating system version.
+        /// </param>
+        /// <param name="expectedArchitecture">
+        /// The epxected processor achitecture.
+        /// </param>
+        /// <param name="expectedQualifiers">
+        /// Any expected additional qualifiers.
+        /// </param>
+        [Theory]
+        [InlineData(null, null, null, null, null)]
+        [InlineData("any", "any", null, null, null)]
+        [InlineData("win", "win", null, null, null)]
+        [InlineData("win-x86", "win", null, Architecture.X86, null)]
+        [InlineData("win-x64", "win", null, Architecture.X64, null)]
+        [InlineData("win7", "win", "7", null, null)]
+        [InlineData("win7-x86", "win", "7", Architecture.X86, null)]
+        [InlineData("win7-x64", "win", "7", Architecture.X64, null)]
+        [InlineData("win8-x86", "win", "8", Architecture.X86, null)]
+        [InlineData("win8-x64", "win", "8", Architecture.X64, null)]
+        [InlineData("win81-x86", "win", "81", Architecture.X86, null)]
+        [InlineData("win81-x64", "win", "81", Architecture.X64, null)]
+        [InlineData("win10-x86", "win", "10", Architecture.X86, null)]
+        [InlineData("win10-x64", "win", "10", Architecture.X64, null)]
+        [InlineData("alpine-x64", "alpine", null, Architecture.X64, null)]
+        [InlineData("alpine.3.10-x64", "alpine", "3.10", Architecture.X64, null)]
+        [InlineData("linux", "linux", null, null, null)]
+        [InlineData("linux-x86", "linux", null, Architecture.X86, null)]
+        [InlineData("linux-x64", "linux", null, Architecture.X64, null)]
+        [InlineData("linux-arm", "linux", null, Architecture.Arm, null)]
+        [InlineData("linux-arm64", "linux", null, Architecture.Arm64, null)]
+        [InlineData("linux-armel", "linux", null, Architecture.Arm, null)]
+        [InlineData("linux-musl", "linux-musl", null, null, null)]
+        [InlineData("linux-musl-x64", "linux-musl", null, Architecture.X64, null)]
+        [InlineData("ubuntu", "ubuntu", null, null, null)]
+        [InlineData("ubuntu.18.04", "ubuntu", "18.04", null, null)]
+        [InlineData("ubuntu.18.04-x86", "ubuntu", "18.04", Architecture.X86, null)]
+        [InlineData("ubuntu.18.04-x64", "ubuntu", "18.04", Architecture.X64, null)]
+        [InlineData("ubuntu.18.04-arm", "ubuntu", "18.04", Architecture.Arm, null)]
+        [InlineData("ubuntu.18.04-arm64", "ubuntu", "18.04", Architecture.Arm64, null)]
+        [InlineData("ubuntu.18.04-armel", "ubuntu", "18.04", Architecture.Arm, null)]
+        [InlineData("win-aot", "win", null, null, "aot")]
+        [InlineData("win-x86-aot", "win", null, Architecture.X86,"aot")]
+        [InlineData("win-x64-aot", "win", null, Architecture.X64, "aot")]
+        [InlineData("win-arm-aot", "win", null, Architecture.Arm, "aot")]
+        [InlineData("win-arm64-aot", "win", null, Architecture.Arm64, "aot")]
+        [InlineData("win7-x86-aot", "win", "7", Architecture.X86, "aot")]
+        [InlineData("win7-x64-aot", "win", "7", Architecture.X64, "aot")]
+        [InlineData("win7-arm-aot", "win", "7", Architecture.Arm, "aot")]
+        [InlineData("win7-arm64-aot", "win", "7", Architecture.Arm64, "aot")]
+        public void ParseTest(string rid, string expectedOsName, string expectedVersion, Architecture? expectedArchitecture, string expectedQualifiers)
+        {
+            RuntimeIdentifiers.ParseRuntimeId(rid, out string osName, out string version, out Architecture? architecture, out string qualifiers);
+
+            Assert.Equal(expectedOsName, osName);
+            Assert.Equal(expectedVersion, version);
+            Assert.Equal(expectedArchitecture, architecture);
+            Assert.Equal(expectedQualifiers, qualifiers);
+        }
+    }
+}

--- a/Packaging.Targets/RuntimeIdentifiers.cs
+++ b/Packaging.Targets/RuntimeIdentifiers.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Packaging.Targets
+{
+    /// <summary>
+    /// Provides methods for working with .NET Runtime Identifiers.
+    /// </summary>
+    public static class RuntimeIdentifiers
+    {
+        /// <summary>
+        /// Parses a runtime identifier.
+        /// </summary>
+        /// <param name="runtimeId">
+        /// The runtime identifier to parse.
+        /// </param>
+        /// <param name="osName">
+        /// The operating system name embedded in the runtime identifier.
+        /// </param>
+        /// <param name="version">
+        /// The operating system version embedded in the runtime identifier.
+        /// </param>
+        /// <param name="architecture">
+        /// The processor architecture embedded in the runtime identifier.
+        /// </param>
+        /// <param name="qualifiers">
+        /// Any additional qualifiers (such as <c>aot</c>) embedded in the runtime identifier.
+        /// </param>
+        public static void ParseRuntimeId(string runtimeId, out string osName, out string version, out Architecture? architecture, out string qualifiers)
+        {
+            osName = null;
+            version = null;
+            architecture = null;
+            qualifiers = null;
+
+            if (string.IsNullOrEmpty(runtimeId))
+            {
+                return;
+            }
+
+            // We use the following convention in all newly-defined RIDs. Some RIDs (win7-x64, win8-x64) predate this convention and don't follow it, but all new RIDs should follow it. 
+            // [os name].[version]-[architecture]-[additional qualifiers]
+            // See https://github.com/dotnet/corefx/blob/master/pkg/Microsoft.NETCore.Platforms/readme.md#naming-convention
+            int versionSeparator = runtimeId.IndexOf('.');
+            if (versionSeparator >= 0)
+            {
+                osName = runtimeId.Substring(0, versionSeparator);
+            }
+            else
+            {
+                osName = null;
+            }
+
+            // As a special case, for "linux-musl", we consider "-musl" to be part of the osName
+            int muslSeparator = runtimeId.IndexOf("-musl", versionSeparator + 1);
+            int architectureSeparator = runtimeId.IndexOf('-', muslSeparator + 1);
+            if (architectureSeparator >= 0)
+            {
+                if (versionSeparator >= 0)
+                {
+                    version = runtimeId.Substring(versionSeparator + 1, architectureSeparator - versionSeparator - 1);
+                }
+                else
+                {
+                    osName = runtimeId.Substring(0, architectureSeparator);
+                    version = null;
+                }
+
+                qualifiers = runtimeId.Substring(architectureSeparator + 1);
+            }
+            else
+            {
+                if (versionSeparator >= 0)
+                {
+                    version = runtimeId.Substring(versionSeparator + 1);
+                }
+                else
+                {
+                    osName = runtimeId;
+                    version = null;
+                }
+
+                qualifiers = null;
+            }
+
+            // As a special case, os names like win7, win81 and win10 are processed separately
+            if (osName.StartsWith("win") && osName.Length > 3)
+            {
+                version = osName.Substring(3);
+                osName = "win";
+            }
+
+            architecture = null;
+
+            if (!string.IsNullOrEmpty(qualifiers))
+            {
+                string architectureString = qualifiers;
+                qualifiers = null;
+
+                architectureSeparator = architectureString.IndexOf('-');
+                if (architectureSeparator > 0)
+                {
+                    qualifiers = architectureString.Substring(architectureSeparator + 1);
+                    architectureString = architectureString.Substring(0, architectureSeparator);
+                }
+
+                // As a special case, "armel" is mapped to "arm" for now
+                if (architectureString == "armel")
+                {
+                    architectureString = "arm";
+                }
+
+                if (Enum.TryParse<Architecture>(architectureString, ignoreCase: true, out Architecture parsedArchitecture))
+                {
+                    architecture = parsedArchitecture;
+                }
+                else
+                {
+                    // E.g. in the case of "win-aot"
+                    qualifiers = architectureString;
+                }
+            }
+        }
+    }
+}

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -36,6 +36,7 @@
       <RpmVendor Condition="'$(RpmVendor)' == ''">$(Authors)</RpmVendor>
       <RpmDescription Condition="'$(RpmDescription)' == ''">$(PackageDescription)</RpmDescription>
       <RpmUrl Condition="'$(RpmUrl)' == ''">$(PackageProjectUrl)</RpmUrl>
+      <RpmPackageArchitecture Condition="'$(RpmPackageArchitecture)' == ''"></RpmPackageArchitecture>
   </PropertyGroup>
 
     <Message Text="Creating RPM package $(RpmPath)" Importance="high"/>
@@ -50,6 +51,8 @@
              Content="@(Content)"
              LinuxFolders="@(LinuxFolder)"
              RpmDependencies="@(RpmDependency)"
+             RpmPackageArchitecture="$(RpmPackageArchitecture)"
+             RuntimeIdentifier="$(RuntimeIdentifier)"
              CreateUser="$(CreateUser)"
              UserName="$(UserName)"
              InstallService="$(InstallService)"

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -6,7 +6,6 @@
 
   <Target Name="CreatePackageProperties" DependsOnTargets="Publish">
     <PropertyGroup>
-
       <!-- Use the Version as the PackageVersion, but default to 1.0.0 if an Version has not been set
            and allow the user to override this. -->
       <PackageVersion Condition="'$(PackageVersion)' == '' AND '$(Version)' != ''">$(Version)</PackageVersion>
@@ -72,10 +71,13 @@
       <Prefix Condition="'$(Prefix)' == ''">/usr/share/$(PackagePrefix)</Prefix>
       <PackageName>$(PackagePrefix)</PackageName>
       <UserName Condition="'$(UserName)' == ''">$(PackagePrefix)</UserName>
-      <ServiceName Condition="'$(ServiceName)' == ''">$(PackagePrefix)</ServiceName >
+      <ServiceName Condition="'$(ServiceName)' == ''">$(PackagePrefix)</ServiceName>
       <DebSection Condition="'$(Section)' == ''">misc</DebSection>
       <DebPriority Condition="'$(DebPriority)' == ''">extra</DebPriority>
       <DebHomepage Condition="'$(DebHomepage)' == ''">$(PackageProjectUrl)</DebHomepage>
+
+      <!-- DebPackageArchitecture is the architecture used for the deb package. Values like any, i386, amd64, arm and arm64 are supported -->
+      <DebPackageArchitecture Condition="'$(DebPackageArchitecture)' == ''"></DebPackageArchitecture>
     </PropertyGroup>
     
     <!-- Dependency list from https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/jessie/amd64/Dockerfile 
@@ -106,6 +108,8 @@
              LinuxFolders="@(LinuxFolder)"
              DebDependencies="@(DebDependency)"
              DebDotNetDependencies="@(DebDotNetDependencies)"
+             DebPackageArchitecture="$(DebPackageArchitecture)"
+             RuntimeIdentifier="$(RuntimeIdentifier)"
              CreateUser="$(CreateUser)"
              Maintainer="$(PackageMaintainer)"
              Description="$(PackageDescription)"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ test_script:
   - cmd: cd %APPVEYOR_BUILD_FOLDER%\Packaging.Targets.Tests\
   - cmd: dotnet restore
   - cmd: dotnet build
-  - cmd: dotnet vstest bin\Debug\netcoreapp2.0\Packaging.Targets.Tests.dll /logger:trx;LogFileName=testresults.trx
+  - cmd: dotnet vstest bin\Debug\netcoreapp2.1\Packaging.Targets.Tests.dll /logger:trx;LogFileName=testresults.trx
   - ps: '& (Join-Path $env:APPVEYOR_BUILD_FOLDER "appveyor-testresults.ps1")'
   - cmd: cd ..
 


### PR DESCRIPTION
Determine the package architecture from the RuntimeIdentifier, instead of hard-coding it to amd64/x86_64.

Fixes #117
Fixes #51