### PR TITLE
Simplify tools acquisition

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,94 @@
+resources:
+  containers:
+  - container: 2.2-bionic
+    image: mcr.microsoft.com/dotnet/core/sdk:2.2-bionic
+  - container: 3.0-disco
+    image: mcr.microsoft.com/dotnet/core/sdk:3.0-disco
+  - container: 3.0-buster
+    image: mcr.microsoft.com/dotnet/core/sdk:3.0-buster
+
+stages:
+- stage: Build
+  jobs:
+  - job: build
+    container: 3.0-buster
+    steps:
+    - bash: |
+        dotnet restore dotnet-packaging.sln
+        dotnet pack dotnet-packaging.sln -c Release -o $(Build.ArtifactStagingDirectory)
+        dotnet test Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
+
+        cp demo/Directory.Build.props $(Build.ArtifactStagingDirectory)
+        cp demo/version.txt $(Build.ArtifactStagingDirectory)
+      displayName: Build
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: $(Build.ArtifactStagingDirectory)
+        artifactName: nuget
+
+- stage: Test
+  jobs:
+  - job: build_package
+    strategy:
+      maxParallel: 8
+      matrix:
+        2.2-bionic-deb:
+          container: 2.2-bionic
+          command: deb
+        2.2-bionic-rpm:
+          container: 2.2-bionic
+          command: rpm
+        2.2-bionic-zip:
+          container: 2.2-bionic
+          command: zip
+        2.2-bionic-tarball:
+          container: 2.2-bionic
+          command: tarball
+
+        3.0-disco-deb:
+          container: 3.0-disco
+          command: deb
+        3.0-disco-rpm:
+          container: 3.0-disco
+          command: rpm
+        3.0-disco-zip:
+          container: 3.0-disco
+          command: zip
+        3.0-disco-tarball:
+          container: 3.0-disco
+          command: tarball
+
+    container: $[ variables['container'] ]
+    steps:
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Build Artifacts
+      inputs:
+        artifactName: nuget
+        downloadPath: $(Build.ArtifactStagingDirectory)
+    - bash: |
+        set -e
+        export PATH="$PATH:/$HOME/.dotnet/tools"
+
+        mkdir test-$(command)/
+        cd test-$(command)
+
+        echo "<configuration><packageSources><add key='local' value='$(Build.ArtifactStagingDirectory)/nuget' /></packageSources></configuration>" > NuGet.config
+        cat NuGet.config
+
+        version=$(cat $(Build.ArtifactStagingDirectory)/nuget/version.txt)
+        echo "Using version $version"
+
+        # Install the dotnet-$(command) tool
+        dotnet tool install --global dotnet-$(command) --version $version --add-source $(Build.ArtifactStagingDirectory)/nuget
+
+        # Create a new console application
+        dotnet new console
+
+        # Install and use dotnet $(command)
+        dotnet $(command) install
+        dotnet $(command)
+      workingDirectory: $(Pipeline.Workspace)
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: $(Pipeline.Workspace)/test-$(command)/bin/Debug/
+        artifactName: artifacts

--- a/Packaging.Targets/DebTask.cs
+++ b/Packaging.Targets/DebTask.cs
@@ -49,7 +49,6 @@ namespace Packaging.Targets
         /// Gets or sets the runtime identifier for which we are currently building.
         /// Used to determine the target architecture of the package.
         /// </summary>
-        [Required]
         public string RuntimeIdentifier { get; set; }
 
         /// <summary>

--- a/Packaging.Targets/RpmTask.cs
+++ b/Packaging.Targets/RpmTask.cs
@@ -71,7 +71,6 @@ namespace Packaging.Targets
         /// Gets or sets the runtime identifier for which we are currently building.
         /// Used to determine the target architecture of the package.
         /// </summary>
-        [Required]
         public string RuntimeIdentifier { get; set; }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -22,21 +22,22 @@ Did we miss anything? Feel free to file a feature request, or send a PR!
 
 ## Installation
 
-First, add the following entry to your `.csproj` file, under the `Project` node.
-
-```xml
-  <ItemGroup>
-    <PackageReference Include="Packaging.Targets" Version="0.1.56" />
-  </ItemGroup>
-```
-
-Then, install the .NET Packaging tools:
+First, install the .NET Packaging tools. You don't need to install all tools if you only plan to use one.
 
 ```bash
 dotnet tool install --global dotnet-zip
 dotnet tool install --global dotnet-tarball
 dotnet tool install --global dotnet-rpm
 dotnet tool install --global dotnet-deb
+```
+
+Then, in your project directory, run `dotnet {zip|tarball|rpm|deb} install` to add the tool to your project:
+
+```bash
+dotnet zip install
+dotnet tarball install
+dotnet rpm install
+dotnet deb install
 ```
 
 ## Usage
@@ -50,6 +51,44 @@ All commands take the following command line arguments:
 * `-c`, `--configuration`: Target configuration. The default for most projects is 'Debug'.
 *  `---version-suffix`: Defines the value for the `$(VersionSuffix)` property in the project.
 
+All arguments are optional.
+
+## Tutorial
+
+Let's create a new console application and package it as a `.deb` file, so we can install it on our Ubuntu machine:
+
+First, create your console application:
+
+```bash
+mkdir my-app
+cd my-app
+dotnet new console
+```
+
+Then, install the dotnet-deb utility:
+
+```bash
+dotnet tool install --global dotnet-deb
+dotnet deb install
+```
+
+All set. Let's package your application as a deb package:
+
+```bash
+dotnet deb
+```
+
+There's now a `bin\Debug\netcoreapp3.0\my-app.1.0.0.deb` file wich you can install:
+
+```bash
+apt-get install bin\Debug\netcoreapp3.0\my-app.1.0.0.deb
+```
+
+Your application is installed into `/usr/local/share/my-app`. Invoke it by running `/usr/local/share/my-app/my-app`:
+
+```bash
+/usr/local/share/my-app/my-app
+```
 
 ### Note
 You can invoke the packaging tools manually, using a MSBuild target instead of using the a .NET Core CLI tool:

--- a/dotnet-deb/Program.cs
+++ b/dotnet-deb/Program.cs
@@ -6,7 +6,7 @@ namespace Dotnet.Packaging
     {
         static int Main(string[] args)
         {
-            PackagingRunner runner = new PackagingRunner("Debian/Ubuntu installer package", "CreateDeb");
+            PackagingRunner runner = new PackagingRunner("Debian/Ubuntu installer package", "CreateDeb", "deb");
             return runner.Run(args);
         }
     }

--- a/dotnet-deb/dotnet-deb.csproj
+++ b/dotnet-deb/dotnet-deb.csproj
@@ -14,6 +14,9 @@ See https://github.com/qmfrederik/dotnet-packaging/ for more information on how 
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   
   <ItemGroup>

--- a/dotnet-rpm/Program.cs
+++ b/dotnet-rpm/Program.cs
@@ -1,15 +1,10 @@
-﻿using McMaster.Extensions.CommandLineUtils;
-using System;
-using System.Diagnostics;
-using System.Text;
-
-namespace Dotnet.Packaging
+﻿namespace Dotnet.Packaging
 {
     public class Program
     {
         public static int Main(string[] args)
         {
-            PackagingRunner runner = new PackagingRunner("RPM package", "CreateRpm");
+            PackagingRunner runner = new PackagingRunner("RPM package", "CreateRpm", "rpm");
             return runner.Run(args);
         }
     }

--- a/dotnet-rpm/dotnet-rpm.csproj
+++ b/dotnet-rpm/dotnet-rpm.csproj
@@ -14,5 +14,8 @@ See https://github.com/qmfrederik/dotnet-packaging/ for more information on how 
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 </Project>

--- a/dotnet-tarball/Program.cs
+++ b/dotnet-tarball/Program.cs
@@ -1,12 +1,10 @@
-using System.Diagnostics;
-
 namespace Dotnet.Packaging
 {
     class Program
     {
         static int Main(string[] args)
         {
-            PackagingRunner runner = new PackagingRunner("tarball", "CreateTarball");
+            PackagingRunner runner = new PackagingRunner("tarball", "CreateTarball", "tarball");
             return runner.Run(args);
         }
     }

--- a/dotnet-tarball/dotnet-tarball.csproj
+++ b/dotnet-tarball/dotnet-tarball.csproj
@@ -14,6 +14,9 @@ See https://github.com/qmfrederik/dotnet-packaging/ for more information on how 
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   
   <ItemGroup>

--- a/dotnet-zip/Program.cs
+++ b/dotnet-zip/Program.cs
@@ -1,12 +1,10 @@
-using System.Diagnostics;
-
 namespace Dotnet.Packaging
 {
     class Program
     {
         static int Main(string[] args)
         {
-            PackagingRunner runner = new PackagingRunner("zip archive", "CreateZip");
+            PackagingRunner runner = new PackagingRunner("zip archive", "CreateZip", "zip");
             return runner.Run(args);
         }
     }

--- a/dotnet-zip/dotnet-zip.csproj
+++ b/dotnet-zip/dotnet-zip.csproj
@@ -14,6 +14,9 @@ See https://github.com/qmfrederik/dotnet-packaging/ for more information on how 
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
To make the dotnet-packaging utilties work, you need to:
- Add a PackageReference to Packaging.Targets
- Run a dotnet restore
- Invoke dotnet {rpm|zip|tarball|deb} or run dotnet msbuild /t:{CreateDeb|...}

The first two steps seem like a bit of overhead.

This PR:
- Introduces the `dotnet {zip|rpm|deb|tarball}` install command, which creates a Directory.Build.props file, which contains the PackageReference
- Updates `dotnet {zip|rpm|deb|tarball}` to automatically run a restore, first