### PR TITLE
Add an '-o | --output' argument

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -86,9 +86,9 @@ stages:
 
         # Install and use dotnet $(command)
         dotnet $(command) install
-        dotnet $(command)
+        dotnet $(command) -o $(Build.ArtifactStagingDirectory)/packages/$(container)
       workingDirectory: $(Pipeline.Workspace)
     - task: PublishBuildArtifacts@1
       inputs:
-        pathToPublish: $(Pipeline.Workspace)/test-$(command)/bin/Debug/
-        artifactName: artifacts
+        pathToPublish: $(Build.ArtifactStagingDirectory)/packages/
+        artifactName: packages

--- a/Packaging.Targets/ArchiveBuilder.cs
+++ b/Packaging.Targets/ArchiveBuilder.cs
@@ -322,7 +322,7 @@ namespace Packaging.Targets
                     {
                         mode = (LinuxFileMode)Convert.ToUInt32(overridenFileMode, 8);
                     }
-                    catch (Exception ex)
+                    catch (Exception)
                     {
                         throw new Exception($"Could not parse the file mode '{overridenFileMode}' for file '{name}'. Make sure to set the LinuxFileMode attriubute to an octal representation of a Unix file mode.");
                     }

--- a/Packaging.Targets/IO/LzmaMT.cs
+++ b/Packaging.Targets/IO/LzmaMT.cs
@@ -4,6 +4,8 @@ namespace Packaging.Targets.IO
 {
 #pragma warning disable SA1307 // Accessible fields must begin with upper-case letter
 #pragma warning disable SA1310 // Field names must not contain underscore
+#pragma warning disable CS0169 // The field '' is never used
+#pragma warning disable IDE0051 // Remove unused private members
     /// <summary>
     /// Multithreading options
     /// </summary>
@@ -147,4 +149,6 @@ namespace Packaging.Targets.IO
     }
 #pragma warning restore SA1307 // Accessible fields must begin with upper-case letter
 #pragma warning restore SA1310 // Field names must not contain underscore
+#pragma warning restore CS0169 // The field '' is never used
+#pragma warning restore IDE0051 // Remove unused private members
 }

--- a/Packaging.Targets/Rpm/RpmPackageCreator.cs
+++ b/Packaging.Targets/Rpm/RpmPackageCreator.cs
@@ -32,13 +32,6 @@ namespace Packaging.Targets.Rpm
         }
 
         /// <summary>
-        /// Gets or sets the number of threads to use when compressing <c>.xz</c> files.
-        /// The default is to use the number of CPUs. You may want to set this to 1 for
-        /// compatibility purposes.
-        /// </summary>
-        public int CompressionThreads { get; set; } = XZOutputStream.DefaultThreads;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="RpmPackageCreator"/> class.
         /// </summary>
         /// <param name="analyzer">
@@ -54,6 +47,13 @@ namespace Packaging.Targets.Rpm
 
             this.analyzer = analyzer;
         }
+
+        /// <summary>
+        /// Gets or sets the number of threads to use when compressing <c>.xz</c> files.
+        /// The default is to use the number of CPUs. You may want to set this to 1 for
+        /// compatibility purposes.
+        /// </summary>
+        public int CompressionThreads { get; set; } = XZOutputStream.DefaultThreads;
 
         /// <summary>
         /// Creates a RPM Package.

--- a/Packaging.Targets/RuntimeIdentifiers.cs
+++ b/Packaging.Targets/RuntimeIdentifiers.cs
@@ -38,7 +38,7 @@ namespace Packaging.Targets
                 return;
             }
 
-            // We use the following convention in all newly-defined RIDs. Some RIDs (win7-x64, win8-x64) predate this convention and don't follow it, but all new RIDs should follow it. 
+            // We use the following convention in all newly-defined RIDs. Some RIDs (win7-x64, win8-x64) predate this convention and don't follow it, but all new RIDs should follow it.
             // [os name].[version]-[architecture]-[additional qualifiers]
             // See https://github.com/dotnet/corefx/blob/master/pkg/Microsoft.NETCore.Platforms/readme.md#naming-convention
             int versionSeparator = runtimeId.IndexOf('.');

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -14,7 +14,8 @@
       <PackagePrefix Condition="'$(PackagePrefix)' == ''">$(TargetName)</PackagePrefix>
       <PackageName Condition="'$(PackageName)' == ''">$(PackagePrefix).$(PackageVersion).$(RuntimeIdentifier)</PackageName>
       <IntermediatePackagePath>$(IntermediateOutputPath)$(PackageName)</IntermediatePackagePath>
-      <PackagePath Condition="'$(PackagePath)' == ''">$(TargetDir)$(PackageName)</PackagePath>
+      <PackageDir Condition="'$(PackageDir)' == ''">(TargetDir)</PackageDir>
+      <PackagePath Condition="'$(PackagePath)' == ''">$([MSBuild]::EnsureTrailingSlash($(PackageDir)))$(PackageName)</PackagePath>
       <CreateUser Condition="'$(CreateUser)' == ''">false</CreateUser>
       <InstallService Condition="'$(InstallService)' == ''">false</InstallService>
       <PackageMaintainer Condition="'$(PackageMaintainer)' == '' AND '$(Authors)' != ''">$(Authors)</PackageMaintainer>
@@ -41,6 +42,8 @@
 
     <Message Text="Creating RPM package $(RpmPath)" Importance="high"/>
 
+    <MakeDir Directories="$(PackageDir)"/>
+    
     <RpmTask PublishDir="$(PublishDir)"
              RpmPath="$(RpmPath)"
              CpioPath="$(CpioPath)"
@@ -99,6 +102,8 @@
       <DebDotNetDependencies Include="zlib1g"/>
       <DebDotNetDependencies Include="libicu52 | libicu53 | libicu54 | libicu55 | libicu56 | libicu57 | libicu58 | libicu59 | libicu60 | libicu61 | libicu62 | libicu63"/>
     </ItemGroup>
+
+    <MakeDir Directories="$(PackageDir)"/>
     
     <DebTask PublishDir="$(PublishDir)" 
              DebPath="$(DebPath)"
@@ -135,6 +140,8 @@
 
     <Message Text="Creating tarball $(TarballPath)" Importance="high"/>
 
+    <MakeDir Directories="$(PackageDir)"/>
+    
     <TarballTask PublishDir="$(PublishDir)"
              TarballPath="$(TarballPath)"/>
   </Target>
@@ -146,6 +153,8 @@
 
     <Message Text="Creating zip package $(ZipPath)" Importance="high"/>
 
+    <MakeDir Directories="$(PackageDir)"/>
+    
     <ZipTask PublishDir="$(PublishDir)"
              ZipPath="$(ZipPath)"/>
   </Target>

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -12,7 +12,8 @@
       <PackageVersion Condition="'$(PackageVersion)' == '' AND '$(Version)' == ''">1.0.0</PackageVersion>
       
       <PackagePrefix Condition="'$(PackagePrefix)' == ''">$(TargetName)</PackagePrefix>
-      <PackageName Condition="'$(PackageName)' == ''">$(PackagePrefix).$(PackageVersion).$(RuntimeIdentifier)</PackageName>
+      <PackageName Condition="'$(PackageName)' == '' AND '$(RuntimeIdentifier)' != ''">$(PackagePrefix).$(PackageVersion).$(RuntimeIdentifier)</PackageName>
+      <PackageName Condition="'$(PackageName)' == ''">$(PackagePrefix).$(PackageVersion)</PackageName>
       <IntermediatePackagePath>$(IntermediateOutputPath)$(PackageName)</IntermediatePackagePath>
       <PackageDir Condition="'$(PackageDir)' == ''">(TargetDir)</PackageDir>
       <PackagePath Condition="'$(PackagePath)' == ''">$([MSBuild]::EnsureTrailingSlash($(PackageDir)))$(PackageName)</PackagePath>

--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ From the command line, run `dotnet rpm`, `dotnet zip` or `dotnet tarball` to cre
 
 All commands take the following command line arguments:
 
-* `-r`, `--runtime`: Required. The target runtime has to be specified in the project file. For example, `win7-x64` or `ubuntu.16.10-x64`.
-* `-f`, `--framework`: Required. The target framework has to be specified in the project file. For example, `netcoreapp1.1` or `net462`.
+* `-r`, `--runtime`: The target runtime to build your project for. For example, `win7-x64` or `ubuntu.16.10-x64`.
+* `-f`, `--framework`: The target framework to build your project for. For example, `netcoreapp1.1` or `net462`.
 * `-c`, `--configuration`: Target configuration. The default for most projects is 'Debug'.
+* `-o`, `--output`: The output directory to place built packages in.
 *  `---version-suffix`: Defines the value for the `$(VersionSuffix)` property in the project.
+*  `--no-restore`: Skip the implicit call to `dotnet restore`.
 
 All arguments are optional.
 

--- a/dotnet-rpm/PackagingRunner.cs
+++ b/dotnet-rpm/PackagingRunner.cs
@@ -40,12 +40,17 @@ namespace Dotnet.Packaging
 
             CommandOption framework = commandLineApplication.Option(
               "-f | --framework <framework>",
-              $"Required. Target framework of the {outputName}. The target framework has to be specified in the project file.",
+              $"Target framework of the {outputName}. The target framework has to be specified in the project file.",
               CommandOptionType.SingleValue);
 
             CommandOption configuration = commandLineApplication.Option(
               "-c | --configuration <configuration>",
-              $"Required. Target configuration of the {outputName}. The default for most projects is 'Debug'.",
+              $"Target configuration of the {outputName}. The default for most projects is 'Debug'.",
+              CommandOptionType.SingleValue);
+
+            CommandOption output = commandLineApplication.Option(
+              "-o | --output <output-dir>",
+              $"The output directory to place built packages in. The default is the output directory of your project.",
               CommandOptionType.SingleValue);
 
             CommandOption versionSuffix = commandLineApplication.Option(
@@ -136,6 +141,11 @@ namespace Dotnet.Packaging
                 if (versionSuffix.HasValue())
                 {
                     msbuildArguments.Append($"/p:VersionSuffix={versionSuffix.Value()} ");
+                }
+
+                if (output.HasValue())
+                {
+                    msbuildArguments.Append($"/p:PackageDir={output.Value()} ");
                 }
 
                 return RunDotnet(msbuildArguments);


### PR DESCRIPTION
This allows you to override the directory in which the .deb/.rpm/... package will be created, similar to `dotnet pack`.

Also fixes StyleCop issues, and an issue where the $(RuntimeIdentifier) would be included in the package name, even if empty.