### PR TITLE
Be more flexible about the package version

### DIFF
--- a/dotnet-rpm/PackagingRunner.cs
+++ b/dotnet-rpm/PackagingRunner.cs
@@ -91,7 +91,9 @@ namespace Dotnet.Packaging
                     const string PackageId = "Packaging.Targets";
                     if (!propsFile.GetItemsByEvaluatedInclude(PackageId).Any(i => i.ItemType == PackageReferenceItemType && i.EvaluatedInclude == PackageId))
                     {
-                        string packageVersion = ThisAssembly.AssemblyInformationalVersion.Replace("+", "-g");
+                        // Using the -* suffix will allow us to match both released and prereleased versions, in the absence
+                        // of https://github.com/AArnott/Nerdbank.GitVersioning/issues/409
+                        string packageVersion = $"{new Version(ThisAssembly.AssemblyFileVersion).ToString(3)}-*";
                         propsFile.AddItem(
                             PackageReferenceItemType,
                             PackageId,


### PR DESCRIPTION
The version number currently always includes the Git commit ID. This is not present for released package versions, resulting in build warnings.

Use a wildcard instead, this should work for both prerelease and released versions.