### PR TITLE
Use Molecule for testing .deb and .rpm packages for self-contained apps

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -73,10 +73,7 @@ stages:
         cd test-$(command)
 
         echo "<configuration><packageSources><add key='local' value='$(Build.ArtifactStagingDirectory)/nuget' /></packageSources></configuration>" > NuGet.config
-        cat NuGet.config
-
         version=$(cat $(Build.ArtifactStagingDirectory)/nuget/version.txt)
-        echo "Using version $version"
 
         # Install the dotnet-$(command) tool
         dotnet tool install --global dotnet-$(command) --version $version --add-source $(Build.ArtifactStagingDirectory)/nuget
@@ -88,7 +85,62 @@ stages:
         dotnet $(command) install
         dotnet $(command) -o $(Build.ArtifactStagingDirectory)/packages/$(container)
       workingDirectory: $(Pipeline.Workspace)
+      displayName: Run dotnet $(command)
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)/packages/
         artifactName: packages
+
+  - job: molecule
+    pool:
+      vmImage: 'ubuntu-18.04'
+    steps:
+    - bash: |
+        set -e
+        export PATH=~/.local/bin/:$PATH
+
+        pip3 install wheel
+        pip3 install --upgrade --user setuptools
+        pip3 install --user molecule
+        pip3 install --user docker-py
+        molecule --version
+        ansible --version
+      displayName: Install molecule
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Build Artifacts
+      inputs:
+        artifactName: nuget
+        downloadPath: $(Build.ArtifactStagingDirectory)
+    - bash: |
+        set -e
+        export PATH="$PATH:/$HOME/.dotnet/tools"
+
+        cd self-contained-app
+
+        echo "<configuration><packageSources><add key='local' value='$(Build.ArtifactStagingDirectory)/nuget' /></packageSources></configuration>" > NuGet.config
+        version=$(cat $(Build.ArtifactStagingDirectory)/nuget/version.txt)
+
+        # Install the dotnet-rpm and dotnet-deb tools
+        dotnet tool install --global dotnet-deb --version $version --add-source $(Build.ArtifactStagingDirectory)/nuget
+        dotnet tool install --global dotnet-rpm --version $version --add-source $(Build.ArtifactStagingDirectory)/nuget
+
+        # Create .deb and .rpm packages
+        dotnet rpm install
+        dotnet rpm -o $(Build.SourcesDirectory)/molecule/self-contained/
+        dotnet deb -o $(Build.SourcesDirectory)/molecule/self-contained/
+      workingDirectory: $(Build.SourcesDirectory)/molecule/self-contained
+      displayName: Build self-contained-app
+    - bash: |
+        set -e
+        export PATH=~/.local/bin/:$PATH
+
+        molecule test
+      workingDirectory: $(Build.SourcesDirectory)/molecule/self-contained
+      displayName: Run molecule tests for self-contained-app
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: 'pytest.xml'
+        searchFolder: '$(Build.SourcesDirectory)/molecule/self-contained/molecule/default/'
+      condition: always()
+      displayName: Publish test results

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ obj/
 *.pkg
 *.zip
 *.tar.gz
+__pycache__/

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -39,7 +39,33 @@
       <RpmDescription Condition="'$(RpmDescription)' == ''">$(PackageDescription)</RpmDescription>
       <RpmUrl Condition="'$(RpmUrl)' == ''">$(PackageProjectUrl)</RpmUrl>
       <RpmPackageArchitecture Condition="'$(RpmPackageArchitecture)' == ''"></RpmPackageArchitecture>
-  </PropertyGroup>
+    </PropertyGroup>
+
+    <!--
+        Default list of RPM dependencies.
+
+        This list is base don the dependencies defined here:
+        https://github.com/dotnet/core-setup/blob/release/2.1/src/pkg/packaging/rpm/
+        https://github.com/dotnet/core-setup/blob/release/2.2/src/pkg/packaging/rpm/
+        https://github.com/dotnet/core-setup/blob/master/src/pkg/packaging/rpm/
+    
+        The syntax for "boolean dependencies" is described here (available starting
+        with rpm 3.14):
+        https://rpm.org/user_doc/boolean_dependencies.html
+
+        You can search for packages here:
+        https://apps.fedoraproject.org/packages/
+        https://software.opensuse.org/find
+
+        NOTE
+        - Upstream lists compat libraries for OpenSSL 1.0 instead of OpenSSL 1.1, that
+          seems like an oversight.
+        -->
+    <ItemGroup Condition="'@(RpmDependency)' == ''">
+      <RpmDependency Include="openssl-libs" Version="" />
+      <RpmDependency Include="libicu" Version="" />
+      <RpmDependency Include="krb5-libs" Version="" />
+    </ItemGroup>
 
     <Message Text="Creating RPM package $(RpmPath)" Importance="high"/>
 
@@ -87,20 +113,14 @@
       <DebPackageArchitecture Condition="'$(DebPackageArchitecture)' == ''"></DebPackageArchitecture>
     </PropertyGroup>
     
-    <!-- Dependency list from https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/jessie/amd64/Dockerfile 
-         and https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/stretch/amd64/Dockerfile,
-         See also https://github.com/dotnet/core-setup/blob/master/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_debian.9-x64.json  -->
+    <!-- Dependency list from https://github.com/dotnet/core-setup/blob/release/3.0/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config.json  -->
     <ItemGroup Condition="'@(DebDotNetDependencies)' == ''">
-      <DebDotNetDependencies Include="libc6"/>
-      <DebDotNetDependencies Include="libcurl4 | libcurl3"/>
+      <DebDotNetDependencies Include="libc6"/>  
       <DebDotNetDependencies Include="libgcc1"/>
       <DebDotNetDependencies Include="libgssapi-krb5-2"/>
-      <DebDotNetDependencies Include="liblttng-ust0"/>
-      <DebDotNetDependencies Include="libssl1.1 | libssl1.0.2 | libssl1.0.1 | libssl1.0.0 | libssl0.9.8"/>
       <DebDotNetDependencies Include="libstdc++6"/>
-      <DebDotNetDependencies Include="libunwind8"/>
-      <DebDotNetDependencies Include="libuuid1"/>
       <DebDotNetDependencies Include="zlib1g"/>
+      <DebDotNetDependencies Include="libssl1.1 | libssl1.0.2 | libssl1.0.1 | libssl1.0.0 | libssl0.9.8"/>
       <DebDotNetDependencies Include="libicu63 | libicu62 | libicu61 | libicu60 | libicu59 | libicu58 | libicu57 | libicu56 | libicu55 | libicu54 | libicu53 | libicu52"/>
     </ItemGroup>
 

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -92,16 +92,16 @@
          See also https://github.com/dotnet/core-setup/blob/master/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_debian.9-x64.json  -->
     <ItemGroup Condition="'@(DebDotNetDependencies)' == ''">
       <DebDotNetDependencies Include="libc6"/>
-      <DebDotNetDependencies Include="libcurl3 | libcurl4"/>
+      <DebDotNetDependencies Include="libcurl4 | libcurl3"/>
       <DebDotNetDependencies Include="libgcc1"/>
       <DebDotNetDependencies Include="libgssapi-krb5-2"/>
       <DebDotNetDependencies Include="liblttng-ust0"/>
-      <DebDotNetDependencies Include="libssl0.9.8 | libssl1.0.0 | libssl1.0.1 | libssl1.0.2 | libssl1.1"/>
+      <DebDotNetDependencies Include="libssl1.1 | libssl1.0.2 | libssl1.0.1 | libssl1.0.0 | libssl0.9.8"/>
       <DebDotNetDependencies Include="libstdc++6"/>
       <DebDotNetDependencies Include="libunwind8"/>
       <DebDotNetDependencies Include="libuuid1"/>
       <DebDotNetDependencies Include="zlib1g"/>
-      <DebDotNetDependencies Include="libicu52 | libicu53 | libicu54 | libicu55 | libicu56 | libicu57 | libicu58 | libicu59 | libicu60 | libicu61 | libicu62 | libicu63"/>
+      <DebDotNetDependencies Include="libicu63 | libicu62 | libicu61 | libicu60 | libicu59 | libicu58 | libicu57 | libicu56 | libicu55 | libicu54 | libicu53 | libicu52"/>
     </ItemGroup>
 
     <MakeDir Directories="$(PackageDir)"/>

--- a/molecule/self-contained/.yamllint
+++ b/molecule/self-contained/.yamllint
@@ -1,0 +1,13 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/molecule/self-contained/meta/main.yml
+++ b/molecule/self-contained/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  author: Frederik Carlier
+  description: |
+    Ansible Role to deploy a self-contained app created with dotnet deb or dotnet rpm
+    to a machine. Used to test dotnet deb and dotnet rpm.
+  license: MIT
+  min_ansible_version: 1.2
+  galaxy_tags: []
+  platforms:
+    - name: Debian
+    - name: Ubuntu
+    - name: CentOS
+dependencies: []

--- a/molecule/self-contained/molecule/default/Dockerfile.j2
+++ b/molecule/self-contained/molecule/default/Dockerfile.j2
@@ -1,0 +1,18 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+# Patched for RHEL 8 support via
+# https://github.com/ansible/molecule/issues/2348
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+    elif [ $(command -v dnf) ] && [ $(rpm -E %{rhel}) -eq 8 ]; then dnf makecache && dnf --assumeyes install python3 python3-devel python3-dnf python3-pip bash iproute sudo && dnf clean all; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi
+

--- a/molecule/self-contained/molecule/default/molecule.yml
+++ b/molecule/self-contained/molecule/default/molecule.yml
@@ -1,0 +1,69 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  # This list should be roughly kept in sync with the list of supported OSes described at
+  # https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0-supported-os.md,
+  # and/or the list of OSes for which .NET Core builds packages, as seen at
+  # https://dotnet.microsoft.com/download/linux-package-manager/sdk-current
+  # There are no Docker images for RHEL, so we can't test that.
+  # Not sure about Linux Mint/Suse Enterprise Linux docker images, so they are skipped for now.
+  #
+  # OpenSUSE uses zypper as the package manager, but zypper doesn't seem to
+  # handle RPM boolean dependencies. Installing the rpm package will fail like
+  # this:
+  #
+  # > Problem: nothing provides (openssl-libs or libopenssl1_1 or libopenssl_1_0_0) >=  needed by self-contained-app-1.0.0-0.x86_64
+  #
+  # You can manually install the package using rpm -i {path_to_rpm}, though, but Ansible doesn't provide
+  # a good way to do that.
+  #
+  # - name: opensuse.15.0
+  #   image: opensuse/leap:15.0
+  # - name: opensuse.15.1
+  #   image: opensuse/leap:15.1
+  # - name: opensuse.15.2
+  #   image: opensuse/leap:15.2
+  - name: centos.7
+    image: centos:7
+  - name: centos.8
+    image: centos:8
+  - name: ol.7
+    image: oraclelinux:7
+  - name: ol.8
+    image: oraclelinux:8
+  - name: fedora.30
+    image: fedora:30
+  - name: fedora.29
+    image: fedora:29
+  - name: debian.8
+    image: debian:8
+  - name: debian.9
+    image: debian:9
+  - name: debian.10
+    image: debian:10
+  - name: ubuntu.14.04
+    image: ubuntu:14.04
+  - name: ubuntu.16.04
+    image: ubuntu:16.04
+  - name: ubuntu.18.04
+    image: ubuntu:18.04
+  - name: ubuntu.19.10
+    image: ubuntu:19.10
+
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  options:
+    junitxml: pytest.xml
+  lint:
+    name: flake8

--- a/molecule/self-contained/molecule/default/molecule.yml
+++ b/molecule/self-contained/molecule/default/molecule.yml
@@ -59,6 +59,11 @@ provisioner:
   name: ansible
   lint:
     name: ansible-lint
+  inventory:
+    host_vars:
+      fedora.30:
+        # https://github.com/ansible/ansible/issues/54855
+        ansible_python_interpreter: /usr/bin/python3
 scenario:
   name: default
 verifier:

--- a/molecule/self-contained/molecule/default/playbook.yml
+++ b/molecule/self-contained/molecule/default/playbook.yml
@@ -1,0 +1,5 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: self-contained

--- a/molecule/self-contained/molecule/default/tests/test_default.py
+++ b/molecule/self-contained/molecule/default/tests/test_default.py
@@ -1,0 +1,10 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_package_is_runnable(host):
+    host.run_test("/usr/share/self-contained-app/self-contained-app")

--- a/molecule/self-contained/self-contained-app/Program.cs
+++ b/molecule/self-contained/self-contained-app/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace self_contained_app
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/molecule/self-contained/self-contained-app/self-contained-app.csproj
+++ b/molecule/self-contained/self-contained-app/self-contained-app.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RootNamespace>self_contained_app</RootNamespace>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+</Project>

--- a/molecule/self-contained/tasks/deb.yml
+++ b/molecule/self-contained/tasks/deb.yml
@@ -1,0 +1,10 @@
+---
+- name: Copy self-contained app to guest
+  copy:
+    src: "{{ role_path }}/self-contained-app.1.0.0.linux-x64.deb"
+    dest: /home/self-contained-app.1.0.0.linux-x64.deb
+
+- name: Install self-contained app
+  become: true
+  apt:
+    deb: /home/self-contained-app.1.0.0.linux-x64.deb

--- a/molecule/self-contained/tasks/main.yml
+++ b/molecule/self-contained/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- include_tasks: deb.yml
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
+- include_tasks: rpm.yml
+  when: >
+    ansible_distribution == 'CentOS'
+    or ansible_distribution == 'RedHat'
+    or ansible_distribution == 'OracleLinux'
+    or ansible_distribution == 'Fedora'
+    or ansible_distribution == 'openSUSE Leap'

--- a/molecule/self-contained/tasks/rpm.yml
+++ b/molecule/self-contained/tasks/rpm.yml
@@ -1,0 +1,14 @@
+---
+- name: Copy self-contained app to guest
+  copy:
+    src: "{{ role_path }}/self-contained-app.1.0.0.linux-x64.rpm"
+    dest: /home/self-contained-app.1.0.0.linux-x64.rpm
+
+- name: Install self-contained app
+  become: true
+  yum:
+    name: /home/self-contained-app.1.0.0.linux-x64.rpm
+    state: present
+    # We sign RPM packages with a PGP key, but don't export the PGP key yet.
+    # Skip GPG checks for now.
+    disable_gpg_check: true


### PR DESCRIPTION
We currently use some bash scripts to verify the installation of the .deb and .rpm packages during CI.

This PR replaces that with Molecule. This approach:
- Uses Docker containers as test environments
- Uses an Ansible module to push the .rpm/.deb packages to the container
- Uses testinfra to verify the state of the container. Currently the only test which is executed, is to launch the self-contained app, which should print "Hello, World".

As part of this PR, the dependencies for self-contained apps have also been rationalized to mach what the .NET Core runtime itself requires. Some dependencies (like libcurl, libunwind,...) have been removed.

Fedora currently isn't supported because:
- It is the only .rpm-based distro which uses a naming convention for packages which differs from those used by RedHat
- [boolean dependencies](https://rpm.org/user_doc/boolean_dependencies.html) doesn't seem to work (yet)