### PR TITLE
Add support for framework-dependent deployments

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -94,6 +94,13 @@ stages:
   - job: molecule
     pool:
       vmImage: 'ubuntu-18.04'
+    strategy:
+      maxParallel: 8
+      matrix:
+        self-contained:
+          suite: self-contained
+        framework-dependent-app:
+          suite: framework-dependent
     steps:
     - bash: |
         set -e
@@ -115,7 +122,7 @@ stages:
         set -e
         export PATH="$PATH:/$HOME/.dotnet/tools"
 
-        cd self-contained-app
+        cd $(suite)-app
 
         echo "<configuration><packageSources><add key='local' value='$(Build.ArtifactStagingDirectory)/nuget' /></packageSources></configuration>" > NuGet.config
         version=$(cat $(Build.ArtifactStagingDirectory)/nuget/version.txt)
@@ -126,21 +133,21 @@ stages:
 
         # Create .deb and .rpm packages
         dotnet rpm install
-        dotnet rpm -o $(Build.SourcesDirectory)/molecule/self-contained/
-        dotnet deb -o $(Build.SourcesDirectory)/molecule/self-contained/
-      workingDirectory: $(Build.SourcesDirectory)/molecule/self-contained
-      displayName: Build self-contained-app
+        dotnet rpm -o $(Build.SourcesDirectory)/molecule/$(suite)/
+        dotnet deb -o $(Build.SourcesDirectory)/molecule/$(suite)/
+      workingDirectory: $(Build.SourcesDirectory)/molecule/$(suite)
+      displayName: Build $(suite)-app
     - bash: |
         set -e
         export PATH=~/.local/bin/:$PATH
 
         molecule test
-      workingDirectory: $(Build.SourcesDirectory)/molecule/self-contained
-      displayName: Run molecule tests for self-contained-app
+      workingDirectory: $(Build.SourcesDirectory)/molecule/$(suite)
+      displayName: Run molecule tests for $(suite)-app
     - task: PublishTestResults@2
       inputs:
         testResultsFormat: 'JUnit'
         testResultsFiles: 'pytest.xml'
-        searchFolder: '$(Build.SourcesDirectory)/molecule/self-contained/molecule/default/'
+        searchFolder: '$(Build.SourcesDirectory)/molecule/$(suite)/molecule/default/'
       condition: always()
       displayName: Publish test results

--- a/Packaging.Targets.Tests/Deb/DebTaskTests.cs
+++ b/Packaging.Targets.Tests/Deb/DebTaskTests.cs
@@ -16,13 +16,13 @@ namespace Packaging.Targets.Tests.Deb
         /// <param name="packageAchitecture">
         /// The expected package architecture.
         /// </param>
-        [InlineData(null, "any")]
-        [InlineData("ubuntu.18.04", "any")]
+        [InlineData(null, "all")]
+        [InlineData("ubuntu.18.04", "all")]
         [InlineData("ubuntu.18.04-x86", "i386")]
         [InlineData("ubuntu.18.04-x64", "amd64")]
         [InlineData("ubuntu.18.04-arm", "armhf")]
         [InlineData("ubuntu.18.04-arm64", "arm64")]
-        [InlineData("linux", "any")]
+        [InlineData("linux", "all")]
         [InlineData("linux-x86", "i386")]
         [InlineData("linux-x64", "amd64")]
         [InlineData("linux-arm", "armhf")]

--- a/Packaging.Targets.Tests/Rpm/RpmTaskTests.cs
+++ b/Packaging.Targets.Tests/Rpm/RpmTaskTests.cs
@@ -16,13 +16,13 @@ namespace Packaging.Targets.Tests.Rpm
         /// <param name="packageAchitecture">
         /// The expected package architecture.
         /// </param>
-        [InlineData(null, "any")]
-        [InlineData("ubuntu.18.04", "any")]
-        [InlineData("ubuntu.18.04-x86", "i386")]
-        [InlineData("ubuntu.18.04-x64", "x86_64")]
-        [InlineData("ubuntu.18.04-arm", "armhfp")]
-        [InlineData("ubuntu.18.04-arm64", "aarch64")]
-        [InlineData("linux", "any")]
+        [InlineData(null, "noarch")]
+        [InlineData("centos.7", "noarch")]
+        [InlineData("centos.7-x86", "i386")]
+        [InlineData("centos.7-x64", "x86_64")]
+        [InlineData("centos.7-arm", "armhfp")]
+        [InlineData("centos.7-arm64", "aarch64")]
+        [InlineData("linux", "noarch")]
         [InlineData("linux-x86", "i386")]
         [InlineData("linux-x64", "x86_64")]
         [InlineData("linux-arm", "armhfp")]

--- a/Packaging.Targets/DebTask.cs
+++ b/Packaging.Targets/DebTask.cs
@@ -171,7 +171,7 @@ namespace Packaging.Targets
                 }
             }
 
-            return "any";
+            return "all";
         }
 
         public override bool Execute()

--- a/Packaging.Targets/RpmTask.cs
+++ b/Packaging.Targets/RpmTask.cs
@@ -234,7 +234,7 @@ namespace Packaging.Targets
                 }
             }
 
-            return "any";
+            return "noarch";
         }
 
         public override bool Execute()

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -61,7 +61,19 @@
         - Upstream lists compat libraries for OpenSSL 1.0 instead of OpenSSL 1.1, that
           seems like an oversight.
         -->
-    <ItemGroup Condition="'@(RpmDependency)' == ''">
+    <ItemGroup Condition="'@(RpmDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp2.1'">
+      <RpmDependency Include="dotnet-runtime-2.1" Version="" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'@(RpmDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp2.2'">
+      <RpmDependency Include="dotnet-runtime-2.2" Version="" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'@(RpmDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp3.0'">
+      <RpmDependency Include="dotnet-runtime-3.0" Version="" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'@(RpmDependency)' == '' AND '$(RuntimeIdentifier)' != ''">
       <RpmDependency Include="openssl-libs" Version="" />
       <RpmDependency Include="libicu" Version="" />
       <RpmDependency Include="krb5-libs" Version="" />
@@ -113,8 +125,20 @@
       <DebPackageArchitecture Condition="'$(DebPackageArchitecture)' == ''"></DebPackageArchitecture>
     </PropertyGroup>
     
+    <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp2.1'">
+      <DebDotNetDependencies Include="dotnet-runtime-2.1"/>
+    </ItemGroup>
+    
+    <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp2.2'">
+      <DebDotNetDependencies Include="dotnet-runtime-2.2"/>
+    </ItemGroup>
+    
+    <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp3.0'">
+      <DebDotNetDependencies Include="dotnet-runtime-3.0"/>
+    </ItemGroup>
+
     <!-- Dependency list from https://github.com/dotnet/core-setup/blob/release/3.0/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config.json  -->
-    <ItemGroup Condition="'@(DebDotNetDependencies)' == ''">
+    <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' != ''">
       <DebDotNetDependencies Include="libc6"/>  
       <DebDotNetDependencies Include="libgcc1"/>
       <DebDotNetDependencies Include="libgssapi-krb5-2"/>

--- a/molecule/framework-dependent/.yamllint
+++ b/molecule/framework-dependent/.yamllint
@@ -1,0 +1,13 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/molecule/framework-dependent/framework-dependent-app/Program.cs
+++ b/molecule/framework-dependent/framework-dependent-app/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace framework_dependent_app
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
+++ b/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RootNamespace>framework_dependent_app</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/molecule/framework-dependent/meta/main.yml
+++ b/molecule/framework-dependent/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  author: Frederik Carlier
+  description: |
+    Ansible Role to deploy a framework-dependent app created with dotnet deb or dotnet rpm
+    to a machine. Used to test dotnet deb and dotnet rpm.
+  license: MIT
+  min_ansible_version: 1.2
+  galaxy_tags: []
+  platforms:
+    - name: Debian
+    - name: Ubuntu
+    - name: CentOS
+dependencies: []

--- a/molecule/framework-dependent/molecule/default/Dockerfile.j2
+++ b/molecule/framework-dependent/molecule/default/Dockerfile.j2
@@ -1,0 +1,18 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+# Patched for RHEL 8 support via
+# https://github.com/ansible/molecule/issues/2348
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+    elif [ $(command -v dnf) ] && [ $(rpm -E %{rhel}) -eq 8 ]; then dnf makecache && dnf --assumeyes install python3 python3-devel python3-dnf python3-pip bash iproute sudo && dnf clean all; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi
+

--- a/molecule/framework-dependent/molecule/default/molecule.yml
+++ b/molecule/framework-dependent/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
 lint:
   name: yamllint
 platforms:
-  # This list should be roughly kept in sync with the list of 
+  # This list should be roughly kept in sync with the list of
   # OSes for which .NET Core builds packages, as seen at
   # https://dotnet.microsoft.com/download/linux-package-manager/sdk-current
   # There are no Docker images for RHEL, so we can't test that.

--- a/molecule/framework-dependent/molecule/default/molecule.yml
+++ b/molecule/framework-dependent/molecule/default/molecule.yml
@@ -1,0 +1,50 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  # This list should be roughly kept in sync with the list of 
+  # OSes for which .NET Core builds packages, as seen at
+  # https://dotnet.microsoft.com/download/linux-package-manager/sdk-current
+  # There are no Docker images for RHEL, so we can't test that.
+  # Not sure about Linux Mint/Suse Enterprise Linux docker images, so they are skipped for now.
+  # - name: opensuse.15.1
+  #   image: opensuse/leap:15.1
+  # - name: opensuse.15.2
+  #   image: opensuse/leap:15.2
+  - name: ubuntu.16.04
+    image: ubuntu:16.04
+  - name: ubuntu.18.04
+    image: ubuntu:18.04
+  - name: ubuntu.19.04
+    image: ubuntu:19.04
+  - name: debian.9
+    image: debian:9
+  - name: debian.10
+    image: debian:10
+  - name: fedora.29
+    image: fedora:29
+  - name: fedora.30
+    image: fedora:30
+  - name: centos.7
+    image: centos:7
+  - name: opensuse.15.0
+    image: opensuse/leap:15.0
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  inventory:
+    host_vars:
+      fedora.30:
+        # https://github.com/ansible/ansible/issues/54855
+        ansible_python_interpreter: /usr/bin/python3
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/framework-dependent/molecule/default/playbook.yml
+++ b/molecule/framework-dependent/molecule/default/playbook.yml
@@ -1,0 +1,5 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: framework-dependent

--- a/molecule/framework-dependent/molecule/default/tests/test_default.py
+++ b/molecule/framework-dependent/molecule/default/tests/test_default.py
@@ -1,0 +1,10 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_package_is_runnable(host):
+    host.run_test("/usr/share/framework-dependent-app/framework-dependent-app")

--- a/molecule/framework-dependent/tasks/deb.yml
+++ b/molecule/framework-dependent/tasks/deb.yml
@@ -8,9 +8,9 @@
   become: true
   apt:
     pkg:
-    - gnupg
-    - apt-transport-https
-    - ca-certificates
+      - gnupg
+      - apt-transport-https
+      - ca-certificates
 
 - name: Import Microsoft APT key
   apt_key:
@@ -30,5 +30,5 @@
 - name: Install framework-dependent app
   become: true
   apt:
-    update_cache: yes
+    update_cache: true
     deb: /home/framework-dependent-app.1.0.0.deb

--- a/molecule/framework-dependent/tasks/deb.yml
+++ b/molecule/framework-dependent/tasks/deb.yml
@@ -1,0 +1,34 @@
+---
+- name: Copy framework-dependent app to guest
+  copy:
+    src: "{{ role_path }}/framework-dependent-app.1.0.0.deb"
+    dest: /home/framework-dependent-app.1.0.0.deb
+
+- name: Install dependencies
+  become: true
+  apt:
+    pkg:
+    - gnupg
+    - apt-transport-https
+    - ca-certificates
+
+- name: Import Microsoft APT key
+  apt_key:
+    url: https://packages.microsoft.com/keys/microsoft.asc
+    state: present
+
+- name: Add .NET Core repo
+  apt_repository:
+    repo: >
+      deb [arch=amd64]
+      https://packages.microsoft.com/repos/microsoft-{{ ansible_distribution | lower }}-{{ ansible_distribution_release | lower }}-prod
+      {{ ansible_distribution_release | lower }}
+      main
+    filename: "dotnetdev"
+    state: present
+
+- name: Install framework-dependent app
+  become: true
+  apt:
+    update_cache: yes
+    deb: /home/framework-dependent-app.1.0.0.deb

--- a/molecule/framework-dependent/tasks/main.yml
+++ b/molecule/framework-dependent/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- include_tasks: deb.yml
+  when: >
+    ansible_distribution == 'Debian'
+    or ansible_distribution == 'Ubuntu'
+
+- include_tasks: rpm.yml
+  when: >
+    ansible_distribution == 'CentOS'
+    or ansible_distribution == 'RedHat'
+    or ansible_distribution == 'OracleLinux'
+    or ansible_distribution == 'Fedora'
+    or ansible_distribution == 'openSUSE Leap'

--- a/molecule/framework-dependent/tasks/rpm.yml
+++ b/molecule/framework-dependent/tasks/rpm.yml
@@ -1,0 +1,37 @@
+---
+- name: Copy framework-dependent app to guest
+  copy:
+    src: "{{ role_path }}/framework-dependent-app.1.0.0.rpm"
+    dest: /home/framework-dependent-app.1.0.0.rpm
+
+- name: Add .NET repository
+  yum_repository:
+    name: packages-microsoft-com-prod
+    description: Microsoft .NET RHEL Repository
+    # https://packages.microsoft.com/yumrepos/microsoft-centos7-prod/
+    # https://packages.microsoft.com/yumrepos/microsoft-fedora29-prod/
+    # https://packages.microsoft.com/yumrepos/microsoft-fedora30-prod/
+    baseurl: https://packages.microsoft.com/yumrepos/microsoft-{{ ansible_distribution | lower }}{{ ansible_distribution_major_version }}-prod
+    enabled: yes
+    gpgcheck: yes
+    gpgkey: https://packages.microsoft.com/keys/microsoft.asc
+    state: present
+  when: ansible_distribution != 'openSUSE Leap'
+
+- name: Add .NET repository
+  zypper_repository:
+    name: packages-microsoft-com-prod
+    description: Microsoft .NET RHEL Repository
+    # https://packages.microsoft.com/opensuse/15/prod/
+    repo: 'https://packages.microsoft.com/opensuse/15/prod/'
+    state: present
+  when: ansible_distribution == 'openSUSE Leap'
+
+- name: Install self-contained app
+  become: true
+  yum:
+    name: /home/framework-dependent-app.1.0.0.rpm
+    state: present
+    # We sign RPM packages with a PGP key, but don't export the PGP key yet.
+    # Skip GPG checks for now.
+    disable_gpg_check: true

--- a/molecule/framework-dependent/tasks/rpm.yml
+++ b/molecule/framework-dependent/tasks/rpm.yml
@@ -12,8 +12,8 @@
     # https://packages.microsoft.com/yumrepos/microsoft-fedora29-prod/
     # https://packages.microsoft.com/yumrepos/microsoft-fedora30-prod/
     baseurl: https://packages.microsoft.com/yumrepos/microsoft-{{ ansible_distribution | lower }}{{ ansible_distribution_major_version }}-prod
-    enabled: yes
-    gpgcheck: yes
+    enabled: true
+    gpgcheck: true
     gpgkey: https://packages.microsoft.com/keys/microsoft.asc
     state: present
   when: ansible_distribution != 'openSUSE Leap'


### PR DESCRIPTION
This PR adds support for framework-dependent deployments.

If you run `dotnet deb` or `dotnet rpm` and no `RuntimeIdentifier` is set, the resulting `.deb` and `.rpm` file will be architecture-independent and have a generic dependency on the .NET Core framework.

Includes Molecule tests for deploying to most Linux OSes supported by .NET Core:
* Ubuntu: 16.04, 18.04, 19.04
* Debian: 9, 10
* CentOS: 7
* Fedora: 29, 30
* OpenSUSE: 15
