### PR TITLE
Loosen check for project file to allow VB, F#

### DIFF
--- a/dotnet-rpm/PackagingRunner.cs
+++ b/dotnet-rpm/PackagingRunner.cs
@@ -178,7 +178,7 @@ namespace Dotnet.Packaging
 
         public bool IsPackagingTargetsInstalled()
         {
-            var projectFilePath = Directory.GetFiles(Environment.CurrentDirectory, "*.csproj").SingleOrDefault();
+            var projectFilePath = Directory.GetFiles(Environment.CurrentDirectory, "*.*proj").SingleOrDefault();
 
             if (projectFilePath == null)
             {


### PR DESCRIPTION
In older revisions without the check dotnet-rpm could be used to package any .NET Core project. With this check in place it could only be used for C# projects anymore. This change will restore the previous functionality.