### PR TITLE
Support implicit .NET dependencies for RPM packages, too

### DIFF
--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -61,22 +61,22 @@
         - Upstream lists compat libraries for OpenSSL 1.0 instead of OpenSSL 1.1, that
           seems like an oversight.
         -->
-    <ItemGroup Condition="'@(RpmDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp2.1'">
-      <RpmDependency Include="dotnet-runtime-2.1" Version="" />
+    <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp2.1'">
+      <RpmDotNetDependency Include="dotnet-runtime-2.1" Version="" />
     </ItemGroup>
 
-    <ItemGroup Condition="'@(RpmDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp2.2'">
-      <RpmDependency Include="dotnet-runtime-2.2" Version="" />
+    <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp2.2'">
+      <RpmDotNetDependency Include="dotnet-runtime-2.2" Version="" />
     </ItemGroup>
 
-    <ItemGroup Condition="'@(RpmDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp3.0'">
-      <RpmDependency Include="dotnet-runtime-3.0" Version="" />
+    <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp3.0'">
+      <RpmDotNetDependency Include="dotnet-runtime-3.0" Version="" />
     </ItemGroup>
 
-    <ItemGroup Condition="'@(RpmDependency)' == '' AND '$(RuntimeIdentifier)' != ''">
-      <RpmDependency Include="openssl-libs" Version="" />
-      <RpmDependency Include="libicu" Version="" />
-      <RpmDependency Include="krb5-libs" Version="" />
+    <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' != ''">
+      <RpmDotNetDependency Include="openssl-libs" Version="" />
+      <RpmDotNetDependency Include="libicu" Version="" />
+      <RpmDotNetDependency Include="krb5-libs" Version="" />
     </ItemGroup>
 
     <Message Text="Creating RPM package $(RpmPath)" Importance="high"/>
@@ -92,6 +92,7 @@
              PackageName="$(PackageName)"
              Content="@(Content)"
              LinuxFolders="@(LinuxFolder)"
+             RpmDotNetDependencies="@(RpmDotNetDependency)"
              RpmDependencies="@(RpmDependency)"
              RpmPackageArchitecture="$(RpmPackageArchitecture)"
              RuntimeIdentifier="$(RuntimeIdentifier)"

--- a/demo/cliscd/cliscd.csproj
+++ b/demo/cliscd/cliscd.csproj
@@ -42,34 +42,34 @@
 
   <!-- Fedora, CentOS, and RHEL dependencies -->
   <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('rhel')) OR $(RuntimeIdentifier.StartsWith('fedora')) OR $(RuntimeIdentifier.StartsWith('ol'))">
-    <RpmDependency Include="libstdc++" Version="" />
-    <RpmDependency Include="libunwind" Version="" />
-    <RpmDependency Include="libicu" Version="" />
+    <RpmDotNetDependency Include="libstdc++" Version="" />
+    <RpmDotNetDependency Include="libunwind" Version="" />
+    <RpmDotNetDependency Include="libicu" Version="" />
   </ItemGroup>
 
   <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('rhel')) OR $(RuntimeIdentifier.StartsWith('fedora'))">
-    <RpmDependency Include="compat-openssl10" Version="" />
+    <RpmDotNetDependency Include="compat-openssl10" Version="" />
   </ItemGroup>
 
   <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('ol'))">
-    <RpmDependency Include="openssl-libs" Version="" />
+    <RpmDotNetDependency Include="openssl-libs" Version="" />
   </ItemGroup>
 
   <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('centos'))">
     <!-- <RpmDependency Include="lttng-ust" Version=""/> -->
-    <RpmDependency Include="libcurl" Version="" />
-    <RpmDependency Include="openssl-libs" Version="" />
-    <RpmDependency Include="krb5-libs" Version="" />
-    <RpmDependency Include="libicu" Version="" />
-    <RpmDependency Include="zlib" Version="" />
-    <RpmDependency Include="libunwind" Version="" Condition="'$(TargetFramework)'=='netcoreapp2.0'" />
-    <RpmDependency Include="libuuid" Version="" Condition="'$(TargetFramework)'=='netcoreapp2.0'" />
+    <RpmDotNetDependency Include="libcurl" Version="" />
+    <RpmDotNetDependency Include="openssl-libs" Version="" />
+    <RpmDotNetDependency Include="krb5-libs" Version="" />
+    <RpmDotNetDependency Include="libicu" Version="" />
+    <RpmDotNetDependency Include="zlib" Version="" />
+    <RpmDotNetDependency Include="libunwind" Version="" Condition="'$(TargetFramework)'=='netcoreapp2.0'" />
+    <RpmDotNetDependency Include="libuuid" Version="" Condition="'$(TargetFramework)'=='netcoreapp2.0'" />
   </ItemGroup>
 
   <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('opensuse'))">
-    <RpmDependency Include="libopenssl1_0_0" Version="" />
-    <RpmDependency Include="libicu52_1" Version="" />
-    <RpmDependency Include="krb5" Version="" />
+    <RpmDotNetDependency Include="libopenssl1_0_0" Version="" />
+    <RpmDotNetDependency Include="libicu52_1" Version="" />
+    <RpmDotNetDependency Include="krb5" Version="" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
For Debian packages, we split the list of package-specific dependencies and .NET Core dependencies (either the framework itself or the dependencies of the framework) in two different variables.

Do the same for RPM packages.

This allows you to specify your package-specific dependencies, without having to worry too much about the .NET Core dependencies, getting us one step closer to "it just works"