### PR TITLE
Test & fix extracting .tar.gz packages on macOS

### DIFF
--- a/.azure-pipelines-shared.yml
+++ b/.azure-pipelines-shared.yml
@@ -1,0 +1,31 @@
+steps:
+- task: DownloadBuildArtifacts@0
+  displayName: Download Build Artifacts
+  inputs:
+    artifactName: nuget
+    downloadPath: $(Build.ArtifactStagingDirectory)
+- bash: |
+    set -e
+    export PATH="$PATH:/$HOME/.dotnet/tools"
+
+    mkdir test-$(command)/
+    cd test-$(command)
+
+    echo "<configuration><packageSources><add key='local' value='$(Build.ArtifactStagingDirectory)/nuget' /></packageSources></configuration>" > NuGet.config
+    version=$(cat $(Build.ArtifactStagingDirectory)/nuget/version.txt)
+
+    # Install the dotnet-$(command) tool
+    dotnet tool install --global dotnet-$(command) --version $version --add-source $(Build.ArtifactStagingDirectory)/nuget
+
+    # Create a new console application
+    dotnet new console
+
+    # Install and use dotnet $(command)
+    dotnet $(command) install
+    dotnet $(command) -o $(Build.ArtifactStagingDirectory)/packages/$(container)
+  workingDirectory: $(Pipeline.Workspace)
+  displayName: Run dotnet $(command)
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathToPublish: $(Build.ArtifactStagingDirectory)/packages/
+    artifactName: packages

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,3 +1,6 @@
+trigger:
+- master
+
 resources:
   containers:
   - container: 2.2-bionic
@@ -60,36 +63,7 @@ stages:
 
     container: $[ variables['container'] ]
     steps:
-    - task: DownloadBuildArtifacts@0
-      displayName: Download Build Artifacts
-      inputs:
-        artifactName: nuget
-        downloadPath: $(Build.ArtifactStagingDirectory)
-    - bash: |
-        set -e
-        export PATH="$PATH:/$HOME/.dotnet/tools"
-
-        mkdir test-$(command)/
-        cd test-$(command)
-
-        echo "<configuration><packageSources><add key='local' value='$(Build.ArtifactStagingDirectory)/nuget' /></packageSources></configuration>" > NuGet.config
-        version=$(cat $(Build.ArtifactStagingDirectory)/nuget/version.txt)
-
-        # Install the dotnet-$(command) tool
-        dotnet tool install --global dotnet-$(command) --version $version --add-source $(Build.ArtifactStagingDirectory)/nuget
-
-        # Create a new console application
-        dotnet new console
-
-        # Install and use dotnet $(command)
-        dotnet $(command) install
-        dotnet $(command) -o $(Build.ArtifactStagingDirectory)/packages/$(container)
-      workingDirectory: $(Pipeline.Workspace)
-      displayName: Run dotnet $(command)
-    - task: PublishBuildArtifacts@1
-      inputs:
-        pathToPublish: $(Build.ArtifactStagingDirectory)/packages/
-        artifactName: packages
+    - template: .azure-pipelines-shared.yml
 
   - job: molecule
     pool:
@@ -151,3 +125,42 @@ stages:
         searchFolder: '$(Build.SourcesDirectory)/molecule/$(suite)/molecule/default/'
       condition: always()
       displayName: Publish test results
+
+  - job: build_macos
+    pool:
+      vmImage: 'macOS-10.14'
+    variables:
+      container: macos
+      command: tarball
+    steps:
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core 3.0'
+      inputs:
+        packageType: sdk
+        version: 3.0.100
+    - template: .azure-pipelines-shared.yml
+
+  - job: test_macos
+    pool:
+      vmImage: 'macOS-10.14'
+    dependsOn: build_macos
+    steps:
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Build Artifacts
+      inputs:
+        artifactName: packages
+        downloadPath: $(Build.ArtifactStagingDirectory)/
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core 3.0'
+      inputs:
+        packageType: sdk
+        version: 3.0.100
+    - bash: |
+        set -e
+        tar xvzf $(Build.ArtifactStagingDirectory)/packages/macos/test-tarball.1.0.0.tar.gz
+      displayName: Extract tarball
+    - bash: |
+        set -e
+        chmod +x ./test-tarball
+        ./test-tarball
+      displayName: Execute program

--- a/Packaging.Targets.Tests/Deb/DebTaskTests.cs
+++ b/Packaging.Targets.Tests/Deb/DebTaskTests.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿using Packaging.Targets.IO;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
 
 namespace Packaging.Targets.Tests.Deb
 {
@@ -31,6 +35,71 @@ namespace Packaging.Targets.Tests.Deb
         public void GetPackageArchitectureTest(string runtimeIdentifier, string packageAchitecture)
         {
             Assert.Equal(packageAchitecture, DebTask.GetPackageArchitecture(runtimeIdentifier));
+        }
+
+        [Fact]
+        public void EnsureDirectoriesTest()
+        {
+            List<ArchiveEntry> archiveEntries = new List<ArchiveEntry>();
+            archiveEntries.Add(
+                new ArchiveEntry()
+                {
+                    Mode = LinuxFileMode.S_IROTH | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFREG,
+                    TargetPath = "./ConsoleApp1.deps.json",
+                });
+
+            DebTask.EnsureDirectories(archiveEntries, includeRoot: false);
+
+            // This example contains one entry in the current directory, so no new directory entries should
+            // have been created
+            Assert.Single(archiveEntries);
+        }
+
+        [Fact]
+        public void EnsureDirectoriesTest2()
+        {
+            List<ArchiveEntry> archiveEntries = new List<ArchiveEntry>();
+            archiveEntries.Add(
+                new ArchiveEntry()
+                {
+                    Mode = LinuxFileMode.S_IROTH | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFREG,
+                    TargetPath = "/usr/local/share/consoleapp/ConsoleApp1.deps.json",
+                });
+
+            DebTask.EnsureDirectories(archiveEntries, includeRoot: true);
+
+            archiveEntries = archiveEntries
+                .OrderBy(e => e.TargetPathWithFinalSlash, StringComparer.Ordinal)
+                .ToList();
+
+            // This example contains one entry in the current directory, so no new directory entries should
+            // have been created
+            Assert.Collection(
+                archiveEntries,
+                (e) => Assert.Equal("/", e.TargetPath),
+                (e) => Assert.Equal("/usr", e.TargetPath),
+                (e) => Assert.Equal("/usr/local", e.TargetPath),
+                (e) => Assert.Equal("/usr/local/share", e.TargetPath),
+                (e) => Assert.Equal("/usr/local/share/consoleapp", e.TargetPath),
+                (e) => Assert.Equal("/usr/local/share/consoleapp/ConsoleApp1.deps.json", e.TargetPath));
+        }
+
+        [Fact]
+        public void EnsureDirectoriesTest3()
+        {
+            List<ArchiveEntry> archiveEntries = new List<ArchiveEntry>();
+            archiveEntries.Add(
+                new ArchiveEntry()
+                {
+                    Mode = LinuxFileMode.S_IROTH | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFREG,
+                    TargetPath = "ConsoleApp1.deps.json",
+                });
+
+            DebTask.EnsureDirectories(archiveEntries, includeRoot: false);
+
+            // This example contains one entry in the current directory, so no new directory entries should
+            // have been created
+            Assert.Single(archiveEntries);
         }
     }
 }

--- a/Packaging.Targets/ArchiveBuilder.cs
+++ b/Packaging.Targets/ArchiveBuilder.cs
@@ -293,7 +293,14 @@ namespace Packaging.Targets
 
                 if (name == null)
                 {
-                    name = prefix + "/" + fileName;
+                    if (!string.IsNullOrEmpty(prefix))
+                    {
+                        name = prefix + "/" + fileName;
+                    }
+                    else
+                    {
+                        name = fileName;
+                    }
                 }
 
                 string linkTo = string.Empty;

--- a/Packaging.Targets/DebTask.cs
+++ b/Packaging.Targets/DebTask.cs
@@ -192,7 +192,7 @@ namespace Packaging.Targets
                     this.Content);
 
                 archiveEntries.AddRange(archiveBuilder.FromLinuxFolders(this.LinuxFolders));
-                this.EnsureDirectories(archiveEntries);
+                EnsureDirectories(archiveEntries);
 
                 archiveEntries = archiveEntries
                     .OrderBy(e => e.TargetPathWithFinalSlash, StringComparer.Ordinal)
@@ -268,7 +268,7 @@ namespace Packaging.Targets
             }
         }
 
-        private void EnsureDirectories(List<ArchiveEntry> entries)
+        internal static void EnsureDirectories(List<ArchiveEntry> entries)
         {
             var dirs = new HashSet<string>(entries.Where(x => x.Mode.HasFlag(LinuxFileMode.S_IFDIR))
                 .Select(d => d.TargetPathWithFinalSlash));

--- a/Packaging.Targets/DebTask.cs
+++ b/Packaging.Targets/DebTask.cs
@@ -268,7 +268,7 @@ namespace Packaging.Targets
             }
         }
 
-        internal static void EnsureDirectories(List<ArchiveEntry> entries)
+        internal static void EnsureDirectories(List<ArchiveEntry> entries, bool includeRoot = true)
         {
             var dirs = new HashSet<string>(entries.Where(x => x.Mode.HasFlag(LinuxFileMode.S_IFDIR))
                 .Select(d => d.TargetPathWithFinalSlash));
@@ -285,7 +285,7 @@ namespace Packaging.Targets
 
                 if (!path.Contains("/"))
                 {
-                    return "/";
+                    return string.Empty;
                 }
 
                 return path.Substring(0, path.LastIndexOf('/'));
@@ -293,7 +293,7 @@ namespace Packaging.Targets
 
             void EnsureDir(string dirPath)
             {
-                if (dirPath == string.Empty)
+                if (dirPath == string.Empty || dirPath == ".")
                 {
                     return;
                 }
@@ -325,7 +325,11 @@ namespace Packaging.Targets
                 EnsureDir(GetDirPath(entry.TargetPathWithFinalSlash));
             }
 
-            EnsureDir("/");
+            if (includeRoot)
+            {
+                EnsureDir("/");
+            }
+
             entries.AddRange(toAdd);
         }
     }

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -30,13 +30,10 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SharpZipLib.NETStandard" Version="0.86.0.1">
+    <PackageReference Include="SharpZipLib" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="SharpZipLib.NETStandard" Version="0.86.0.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Buffers" Version="4.5.0" />
@@ -46,9 +43,9 @@
       <Pack>true</Pack>
       <PackagePath>build\</PackagePath>
     </Content>
-    
+
     <!-- SharpZipLib -->
-    <Content Include="$(NuGetPackageRoot)\sharpziplib.netstandard\0.86.0.1\lib\netstandard1.3\SharpZipLib.NETStandard.dll" Link="SharpZipLib.NETStandard.dll">
+    <Content Include="$(NuGetPackageRoot)\sharpziplib\1.2.0\lib\netstandard2.0\ICSharpCode.SharpZipLib.dll" Link="ICSharpCode.SharpZipLib.dll">
       <Pack>true</Pack>
       <PackagePath>tools\netstandard2.0\</PackagePath>
     </Content>

--- a/Packaging.Targets/StreamExtensions.cs
+++ b/Packaging.Targets/StreamExtensions.cs
@@ -81,7 +81,7 @@ namespace Packaging.Targets
         /// <param name="data">
         /// The struct to write to the stram.
         /// </param>
-        public static void WriteStruct<T>(this Stream stream, T data)
+        public static int WriteStruct<T>(this Stream stream, T data)
             where T : struct
         {
             if (stream == null)
@@ -105,6 +105,7 @@ namespace Packaging.Targets
             RespectEndianness<T>(bytes);
 
             stream.Write(bytes, 0, bytes.Length);
+            return bytes.Length;
         }
 
         /// <summary>

--- a/Packaging.Targets/TarballTask.cs
+++ b/Packaging.Targets/TarballTask.cs
@@ -1,10 +1,9 @@
-﻿using ICSharpCode.SharpZipLib.GZip;
-using Microsoft.Build.Framework;
+﻿using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Packaging.Targets.IO;
 using System;
-using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 
 namespace Packaging.Targets
@@ -28,8 +27,6 @@ namespace Packaging.Targets
 
         public override bool Execute()
         {
-            Debugger.Launch();
-
             this.Log.LogMessage(MessageImportance.Normal, "Creating tarball '{0}' from folder '{1}'", this.TarballPath, this.PublishDir);
 
             this.CreateLinuxTarball();
@@ -53,7 +50,7 @@ namespace Packaging.Targets
                 .ToList();
 
             using (var stream = File.Create(this.TarballPath))
-            using (var gzipStream = new GZipOutputStream(stream))
+            using (var gzipStream = new GZipStream(stream, CompressionMode.Compress))
             {
                 TarFileCreator.FromArchiveEntries(archiveEntries, gzipStream);
             }

--- a/Packaging.Targets/TarballTask.cs
+++ b/Packaging.Targets/TarballTask.cs
@@ -3,6 +3,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Packaging.Targets.IO;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
@@ -22,12 +23,13 @@ namespace Packaging.Targets
         public ITaskItem[] Content
         { get; set; }
 
-        [Required]
         public string Prefix
         { get; set; }
 
         public override bool Execute()
         {
+            Debugger.Launch();
+
             this.Log.LogMessage(MessageImportance.Normal, "Creating tarball '{0}' from folder '{1}'", this.TarballPath, this.PublishDir);
 
             this.CreateLinuxTarball();
@@ -44,7 +46,7 @@ namespace Packaging.Targets
                 this.Prefix,
                 this.Content);
 
-            DebTask.EnsureDirectories(archiveEntries);
+            DebTask.EnsureDirectories(archiveEntries, includeRoot: false);
 
             archiveEntries = archiveEntries
                 .OrderBy(e => e.TargetPathWithFinalSlash, StringComparer.Ordinal)

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -182,6 +182,7 @@
   <Target Name="CreateTarball" DependsOnTargets="CreatePackageProperties">
     <PropertyGroup>
       <TarballPath Condition="'$(TarballPath)' == ''">$(PackagePath).tar.gz</TarballPath>
+      <TarballPrefix Condition="'$(TarballPrefix)' == ''">.</TarballPrefix>
     </PropertyGroup>
 
     <Message Text="Creating tarball $(TarballPath)" Importance="high"/>
@@ -189,7 +190,9 @@
     <MakeDir Directories="$(PackageDir)"/>
     
     <TarballTask PublishDir="$(PublishDir)"
-             TarballPath="$(TarballPath)"/>
+                 TarballPath="$(TarballPath)"
+                 Prefix="$(TarballPrefix)"
+                 Content="@(Content)" />
   </Target>
 
   <Target Name="CreateZip" DependsOnTargets="CreatePackageProperties">


### PR DESCRIPTION
The output from `dotnet tarball` includes an empty nameless directory (see #52). This causes `tar xvzf {output}` to fail on macOS:

```
tar: Failed to set default locale
tar: Archive entry has empty or unreadable filename ... skipping.
```

```
~ % tar --version
tar: Failed to set default locale
bsdtar 3.3.2 - libarchive 3.3.2 zlib/1.2.11 liblzma/5.0.5 bz2lib/1.0.6
```

The Tarball uses SharpZipLib and the error seems to originate from there. dotnet-packaging now ships with its own implementation for writing .tar files, so use that instead.

Fixes a couple of bugs/adds unit tests as well:
- Support for relative paths in `DebTask.EnsureDirectories`
- ArchiveBuilder supports `/` or `.` as root for file names
- `TarFileCreator` doesn't require the `Stream` to which it is writing to report on its `Position`, but calculates the position locally.

Fixes #52