### PR TITLE
Install a symlink to the main executable in /usr/local/bin

### DIFF
--- a/Packaging.Targets.Tests/ArchiveBuilderTests.cs
+++ b/Packaging.Targets.Tests/ArchiveBuilderTests.cs
@@ -20,7 +20,7 @@ namespace Packaging.Targets.Tests
         public void FromDirectoryTest()
         {
             ArchiveBuilder builder = new ArchiveBuilder();
-            var entries = builder.FromDirectory("archive", "/opt/demo", Array.Empty<ITaskItem>());
+            var entries = builder.FromDirectory("archive", null, "/opt/demo", Array.Empty<ITaskItem>());
 
             Assert.Equal(2, entries.Count);
 
@@ -68,7 +68,7 @@ namespace Packaging.Targets.Tests
 
             var taskItem = new TaskItem("script.sh", metadata);
             var taskItems = new ITaskItem[] { taskItem };
-            var entries = builder.FromDirectory("archive", "/opt/demo", taskItems);
+            var entries = builder.FromDirectory("archive", null, "/opt/demo", taskItems);
 
             Assert.Equal(2, entries.Count);
 
@@ -99,6 +99,57 @@ namespace Packaging.Targets.Tests
             Assert.Equal("/bin/script.sh", script.TargetPath);
             Assert.Equal("/bin/script.sh", script.TargetPathWithFinalSlash);
             Assert.Equal(ArchiveEntryType.None, script.Type);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="ArchiveBuilder.FromDirectory(string, string, ITaskItem[])"/> method
+        /// </summary>
+        [Fact]
+        public void FromDirectoryWithAppHost()
+        {
+            ArchiveBuilder builder = new ArchiveBuilder();
+            var entries = builder.FromDirectory("archive", "demo", "/opt/demo", Array.Empty<ITaskItem>());
+
+            Assert.Equal(3, entries.Count);
+
+            var readme = entries[0];
+            Assert.Equal("root", readme.Group);
+            Assert.Equal(1L, readme.Inode);
+            Assert.False(readme.IsAscii);
+            Assert.Equal(string.Empty, readme.LinkTo);
+            Assert.Equal(LinuxFileMode.S_IROTH |  LinuxFileMode.S_IRGRP |  LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFREG, readme.Mode);
+            Assert.Equal("root", readme.Owner);
+            Assert.False(readme.RemoveOnUninstall);
+            Assert.Equal(Path.Combine("archive", "README.md"), readme.SourceFilename);
+            Assert.Equal("/opt/demo/README.md", readme.TargetPath);
+            Assert.Equal("/opt/demo/README.md", readme.TargetPathWithFinalSlash);
+            Assert.Equal(ArchiveEntryType.None, readme.Type);
+
+            var script = entries[1];
+            Assert.Equal("root", script.Group);
+            Assert.Equal(2L, script.Inode);
+            Assert.False(script.IsAscii);
+            Assert.Equal(string.Empty, script.LinkTo);
+            Assert.Equal(LinuxFileMode.S_IROTH | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFREG, script.Mode);
+            Assert.Equal("root", script.Owner);
+            Assert.False(script.RemoveOnUninstall);
+            Assert.Equal(Path.Combine("archive", "script.sh"), script.SourceFilename);
+            Assert.Equal("/opt/demo/script.sh", script.TargetPath);
+            Assert.Equal("/opt/demo/script.sh", script.TargetPathWithFinalSlash);
+            Assert.Equal(ArchiveEntryType.None, script.Type);
+
+            var symlink = entries[2];
+            Assert.Equal("root", symlink.Group);
+            Assert.Equal(3L, symlink.Inode);
+            Assert.False(symlink.IsAscii);
+            Assert.Equal("/opt/demo/demo", symlink.LinkTo);
+            Assert.Equal(LinuxFileMode.S_IXOTH | LinuxFileMode.S_IROTH | LinuxFileMode.S_IXGRP | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IXUSR | LinuxFileMode.S_IWUSR | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFLNK, symlink.Mode);
+            Assert.Equal("root", symlink.Owner);
+            Assert.False(symlink.RemoveOnUninstall);
+            Assert.Null(symlink.SourceFilename);
+            Assert.Equal("/usr/local/bin/demo", symlink.TargetPath);
+            Assert.Equal("/usr/local/bin/demo", symlink.TargetPathWithFinalSlash);
+            Assert.Equal(ArchiveEntryType.None, symlink.Type);
         }
     }
 }

--- a/Packaging.Targets/ArchiveBuilder.cs
+++ b/Packaging.Targets/ArchiveBuilder.cs
@@ -188,10 +188,27 @@ namespace Packaging.Targets
         /// <returns>
         /// A list of <see cref="ArchiveEntry"/> objects representing the data in the directory.
         /// </returns>
-        public List<ArchiveEntry> FromDirectory(string directory, string prefix, ITaskItem[] metadata)
+        public List<ArchiveEntry> FromDirectory(string directory, string appHost, string prefix, ITaskItem[] metadata)
         {
             List<ArchiveEntry> value = new List<ArchiveEntry>();
             this.AddDirectory(directory, string.Empty, prefix, value, metadata);
+
+            // Add a symlink to appHost, if available
+            if (appHost != null)
+            {
+                value.Add(
+                    new ArchiveEntry()
+                    {
+                        Mode = LinuxFileMode.S_IXOTH | LinuxFileMode.S_IROTH | LinuxFileMode.S_IXGRP | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IXUSR | LinuxFileMode.S_IWUSR | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFLNK,
+                        Modified = DateTimeOffset.UtcNow,
+                        Group = "root",
+                        Owner = "root",
+                        TargetPath = $"/usr/local/bin/{appHost}",
+                        LinkTo = $"{prefix}/{appHost}",
+                        Inode = this.inode++,
+                    });
+            }
+
             return value;
         }
 

--- a/Packaging.Targets/ArchiveBuilder.cs
+++ b/Packaging.Targets/ArchiveBuilder.cs
@@ -111,8 +111,8 @@ namespace Packaging.Targets
                 }
                 else if (entry.Mode.HasFlag(LinuxFileMode.S_IFLNK))
                 {
-                    using (var fileStrema = file.Open())
-                    using (var reader = new StreamReader(fileStrema, Encoding.UTF8))
+                    using (var fileStream = file.Open())
+                    using (var reader = new StreamReader(fileStream, Encoding.UTF8))
                     {
                         entry.LinkTo = reader.ReadToEnd();
                     }
@@ -206,6 +206,7 @@ namespace Packaging.Targets
                         TargetPath = $"/usr/local/bin/{appHost}",
                         LinkTo = $"{prefix}/{appHost}",
                         Inode = this.inode++,
+                        Sha256 = Array.Empty<byte>(),
                     });
             }
 
@@ -261,7 +262,7 @@ namespace Packaging.Targets
             {
                 if (fileName.StartsWith(".") || fileStream.Length == 0)
                 {
-                    // Skip hidden and empty files - this would case rmplint errors.
+                    // Skip hidden and empty files - this would case rpmlint errors.
                     return;
                 }
 

--- a/Packaging.Targets/DebTask.cs
+++ b/Packaging.Targets/DebTask.cs
@@ -64,6 +64,13 @@ namespace Packaging.Targets
         public string Priority { get; set; }
 
         /// <summary>
+        /// Gets or sets the path to the app host. This is a native executable which loads
+        /// the .NET Core runtime, and invokes the manage assembly. On Linux, it is symlinked
+        /// into ${prefix}/bin.
+        /// </summary>
+        public string AppHost { get; set; }
+
+        /// <summary>
         /// Gets or sets a list of empty folders to create when
         /// installing this package.
         /// </summary>
@@ -188,6 +195,7 @@ namespace Packaging.Targets
                 ArchiveBuilder archiveBuilder = new ArchiveBuilder();
                 var archiveEntries = archiveBuilder.FromDirectory(
                     this.PublishDir,
+                    this.AppHost,
                     this.Prefix,
                     this.Content);
 

--- a/Packaging.Targets/IO/CpioFileCreator.cs
+++ b/Packaging.Targets/IO/CpioFileCreator.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace Packaging.Targets.IO
 {
@@ -132,7 +133,7 @@ namespace Packaging.Targets.IO
                 Signature = "070701",
             };
 
-            cpioFile.Write(cpioHeader, targetPath, new MemoryStream(Array.Empty<byte>()));
+            cpioFile.Write(cpioHeader, targetPath, new MemoryStream(Encoding.UTF8.GetBytes(entry.LinkTo)));
         }
 
         /// <summary>

--- a/Packaging.Targets/IO/TarFileCreator.cs
+++ b/Packaging.Targets/IO/TarFileCreator.cs
@@ -107,7 +107,7 @@ namespace Packaging.Targets.IO
             }
             else
             {
-                type = TarTypeFlag.LnkType;
+                type = TarTypeFlag.SymType;
             }
 
             bool dispose = false;
@@ -137,7 +137,7 @@ namespace Packaging.Targets.IO
                     GroupId = 0,
                     UserId = 0,
                     GroupName = entry.Group,
-                    LinkName = string.Empty,
+                    LinkName = isLink ? entry.LinkTo : string.Empty,
                     Prefix = string.Empty,
                     TypeFlag = type,
                     UserName = entry.Owner,

--- a/Packaging.Targets/Rpm/RpmMetadata.cs
+++ b/Packaging.Targets/Rpm/RpmMetadata.cs
@@ -615,7 +615,7 @@ namespace Packaging.Targets.Rpm
                     modes[i] = (short)file.Mode;
                     rdevs[i] = file.Rdev;
                     mtimes[i] = (int)file.ModifiedTime.ToUnixTimeSeconds();
-                    md5s[i] = BitConverter.ToString(file.MD5Hash).Replace("-", string.Empty).ToLowerInvariant();
+                    md5s[i] = file.MD5Hash == null ? string.Empty : BitConverter.ToString(file.MD5Hash).Replace("-", string.Empty).ToLowerInvariant();
                     linkTos[i] = file.LinkTo;
                     usernames[i] = file.UserName;
                     groupnames[i] = file.GroupName;

--- a/Packaging.Targets/Rpm/RpmPackageCreator.cs
+++ b/Packaging.Targets/Rpm/RpmPackageCreator.cs
@@ -524,6 +524,16 @@ namespace Packaging.Targets.Rpm
                     size = 0x1000;
                 }
 
+                if (entry.Mode.HasFlag(LinuxFileMode.S_IFLNK))
+                {
+                    // RPM uses cpio archives. cpio archives store the target of a symlink as
+                    // the file content (as opposed to tar, which has a dedicated field for this).
+                    // As a result, the file size is equal to the length of the path of the link
+                    // target.
+                    // https://bugzilla.redhat.com/show_bug.cgi?id=1224555 has some background info.
+                    size = (uint)Encoding.UTF8.GetByteCount(entry.LinkTo);
+                }
+
                 RpmFile file = new RpmFile()
                 {
                     Size = (int)size,

--- a/Packaging.Targets/RpmTask.cs
+++ b/Packaging.Targets/RpmTask.cs
@@ -81,6 +81,13 @@ namespace Packaging.Targets
         public string RpmPackageArchitecture { get; set; }
 
         /// <summary>
+        /// Gets or sets the path to the app host. This is a native executable which loads
+        /// the .NET Core runtime, and invokes the manage assembly. On Linux, it is symlinked
+        /// into ${prefix}/bin.
+        /// </summary>
+        public string AppHost { get; set; }
+
+        /// <summary>
         /// Gets or sets a list of empty folders to create when
         /// installing this package.
         /// </summary>
@@ -263,10 +270,12 @@ namespace Packaging.Targets
                 ArchiveBuilder archiveBuilder = new ArchiveBuilder();
                 var archiveEntries = archiveBuilder.FromDirectory(
                     this.PublishDir,
+                    this.AppHost,
                     this.Prefix,
                     this.Content);
 
                 archiveEntries.AddRange(archiveBuilder.FromLinuxFolders(this.LinuxFolders));
+
                 archiveEntries = archiveEntries
                     .OrderBy(e => e.TargetPathWithFinalSlash, StringComparer.Ordinal)
                     .ToList();

--- a/Packaging.Targets/TarballTask.cs
+++ b/Packaging.Targets/TarballTask.cs
@@ -40,6 +40,7 @@ namespace Packaging.Targets
             ArchiveBuilder archiveBuilder = new ArchiveBuilder();
             var archiveEntries = archiveBuilder.FromDirectory(
                 this.PublishDir,
+                null,
                 this.Prefix,
                 this.Content);
 

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -23,6 +23,8 @@
       <PackageMaintainer Condition="'$(PackageMaintainer)' == '' AND '$(Authors)' == ''">Anonymous &lt;noreply@example.com&gt;</PackageMaintainer>
       <PackageDescription Condition="'$(PackageDescription)' == '' AND '$(Description)' != ''">$(Description)</PackageDescription>
       <PackageDescription Condition="'$(PackageDescription)' == '' AND '$(Description)' == ''">$(PackageName) version $(PackageVersion) - $(Release)</PackageDescription>
+      <SymlinkAppHostInBin Condition="'$(SymlinkAppHostInBin)' == ''">true</SymlinkAppHostInBin>
+      <AppHost Condition="'$(AppHost)' == '' AND '$(SymlinkAppHostInBin)' == 'true'">$(AssemblyName)$(_NativeExecutableExtension)</AppHost>
     </PropertyGroup>
   </Target>
 
@@ -90,6 +92,7 @@
              Version="$(PackageVersion)"
              Release="$(Release)"
              PackageName="$(PackageName)"
+             AppHost="$(AppHost)"
              Content="@(Content)"
              LinuxFolders="@(LinuxFolder)"
              RpmDotNetDependencies="@(RpmDotNetDependency)"
@@ -158,6 +161,7 @@
              Prefix="$(Prefix)"
              Version="$(PackageVersion)"
              PackageName="$(PackageName)"
+             AppHost="$(AppHost)"
              Content="@(Content)"
              LinuxFolders="@(LinuxFolder)"
              DebDependencies="@(DebDependency)"

--- a/molecule/framework-dependent/molecule/default/tests/test_default.py
+++ b/molecule/framework-dependent/molecule/default/tests/test_default.py
@@ -8,3 +8,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_package_is_runnable(host):
     host.run_test("/usr/share/framework-dependent-app/framework-dependent-app")
+
+
+def test_package_symlink_is_runnable(host):
+    host.run_test("/usr/local/bin/framework-dependent-app")

--- a/molecule/self-contained/molecule/default/tests/test_default.py
+++ b/molecule/self-contained/molecule/default/tests/test_default.py
@@ -8,3 +8,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_package_is_runnable(host):
     host.run_test("/usr/share/self-contained-app/self-contained-app")
+
+
+def test_package_symlink_is_runnable(host):
+    host.run_test("/usr/local/bin/self-contained-app")


### PR DESCRIPTION
.NET Core applications now include an "app host", that is, a native executable which loads the .NET Runtime and then invokes the managed executable.

This PR adds a symlink to `/usr/local/bin/$(assemblyName)` which links to `$(prefix)/$(assemblyName)`. This means that (in most environments) the project will be executable using just `$(assemblyName)`:

```
fcarlier@fcarlier:~/$ ls -l /usr/local/bin/testapp 
lrwxrwxrwx 1 root root 26 Dec  2 15:33 /usr/local/bin/testapp -> /usr/share/testapp/testapp
```

Fixes #31
Fixes #101