### PR TITLE
Fix rpm/deb generation for files with Link attribute

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet-test-explorer.testProjectPath": "**/*Tests.csproj"
+}

--- a/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
+++ b/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
@@ -8,9 +8,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
-    <PackageReference Include="xunit.analyzers">
-      <Version>0.7.0</Version>
-    </PackageReference>
+    <PackageReference Include="xunit.analyzers" Version="0.7.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
 
     <!-- The BouncyCastle dependency is defined as Private for Packaging.Targets, so we need to re-define it here. -->
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />

--- a/Packaging.Targets.Tests/TaskItemExtensionsTests.cs
+++ b/Packaging.Targets.Tests/TaskItemExtensionsTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+using Moq;
+using Xunit;
+
+namespace Packaging.Targets.Tests
+{
+    public class TaskItemExtensionsTests
+    {
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("DoNotCopy", false)]
+        [InlineData("Always", true)]
+        [InlineData("PreserveNewest", true)]
+        [InlineData("Invalid", false)]
+        public void IsPublishedTest(string copyToPublishDirectory, bool shouldPublish)
+        {
+            var taskItemMock = new Mock<ITaskItem>();
+            Dictionary<string, string> metadata = new Dictionary<string, string>();
+
+            if (copyToPublishDirectory != null)
+            {
+                metadata.Add("CopyToPublishDirectory", copyToPublishDirectory);
+            }
+
+            taskItemMock.Setup(m => m.MetadataNames).Returns(metadata.Keys);
+            taskItemMock.Setup(m => m.GetMetadata("CopyToPublishDirectory")).Returns(() => metadata["CopyToPublishDirectory"]);
+
+            Assert.Equal(shouldPublish, taskItemMock.Object.IsPublished());
+        }
+
+        [Theory]
+        [InlineData("", "", "README", "", "README")]
+        [InlineData("", "", "README", ".md", "README.md")]
+        [InlineData("", "dir\\subdir", "README", ".md", "dir/subdir/README.md")]
+        [InlineData("somelink", "dir\\subdir", "README", ".md", "somelink")]
+        public void GetPublishedPathTest(string link, string relativeDir, string fileName, string extension, string expectedPath)
+        {
+            var taskItemMock = new Mock<ITaskItem>();
+            Dictionary<string, string> metadata = new Dictionary<string, string>();
+
+            metadata.Add("Link", link);
+            metadata.Add("RelativeDir", relativeDir);
+            metadata.Add("FileName", fileName);
+            metadata.Add("Extension", extension);
+
+            taskItemMock.Setup(m => m.MetadataNames).Returns(metadata.Keys);
+            taskItemMock
+                .Setup(m => m.GetMetadata(It.IsAny<string>()))
+                .Returns<string>((k) => metadata[k]);
+
+            Assert.Equal(expectedPath, taskItemMock.Object.GetPublishedPath());
+        }
+    }
+}

--- a/Packaging.Targets/TaskItemExtensions.cs
+++ b/Packaging.Targets/TaskItemExtensions.cs
@@ -59,7 +59,7 @@ namespace Packaging.Targets
             }
 
             var link = item.GetMetadata("Link");
-            if (link != string.Empty)
+            if (!string.IsNullOrEmpty(link))
             {
                 return link.Replace("\\", "/");
             }

--- a/Packaging.Targets/TaskItemExtensions.cs
+++ b/Packaging.Targets/TaskItemExtensions.cs
@@ -58,6 +58,12 @@ namespace Packaging.Targets
                 return null;
             }
 
+            var link = item.GetMetadata("Link");
+            if (link != string.Empty)
+            {
+                return link.Replace("\\", "/");
+            }
+
             var relativeDirectory = item.GetMetadata("RelativeDir");
             var filename = item.GetMetadata("FileName");
             var extension = item.GetMetadata("Extension");

--- a/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
+++ b/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
@@ -6,4 +6,14 @@
     <RootNamespace>framework_dependent_app</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Makes sure a file which is located outside of the project directory structure,
+         but is linked into the project can be deployed correctly.
+         Non-regression test for https://github.com/qmfrederik/dotnet-packaging/issues/81 -->
+    <Content Include="../../../README.md" CopyToPublishDirectory="PreserveNewest">
+      <Link>README.md</Link>
+      <LinuxPath>/etc/dotnet-packaging/README.md</LinuxPath>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/molecule/framework-dependent/molecule/default/tests/test_default.py
+++ b/molecule/framework-dependent/molecule/default/tests/test_default.py
@@ -12,3 +12,7 @@ def test_package_is_runnable(host):
 
 def test_package_symlink_is_runnable(host):
     host.run_test("/usr/local/bin/framework-dependent-app")
+
+
+def test_readme_is_deployed(host):
+    assert host.file("/etc/dotnet-packaging/README.md").exists

--- a/molecule/self-contained/molecule/default/tests/test_default.py
+++ b/molecule/self-contained/molecule/default/tests/test_default.py
@@ -12,3 +12,7 @@ def test_package_is_runnable(host):
 
 def test_package_symlink_is_runnable(host):
     host.run_test("/usr/local/bin/self-contained-app")
+
+
+def test_readme_is_deployed(host):
+    assert host.file("/etc/dotnet-packaging/README.md").exists

--- a/molecule/self-contained/self-contained-app/self-contained-app.csproj
+++ b/molecule/self-contained/self-contained-app/self-contained-app.csproj
@@ -7,4 +7,13 @@
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Makes sure a file which is located outside of the project directory structure,
+         but is linked into the project can be deployed correctly.
+         Non-regression test for https://github.com/qmfrederik/dotnet-packaging/issues/81 -->
+    <Content Include="../../../README.md" CopyToPublishDirectory="PreserveNewest">
+      <Link>README.md</Link>
+      <LinuxPath>/etc/dotnet-packaging/README.md</LinuxPath>
+    </Content>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This fixes an issue where metadata for files with the `Link` attribute would not be applied correctly.

Fixes #81