### PR TITLE
Fix deb/rpm generation with Content file outside project root, file permissions

### DIFF
--- a/Packaging.Targets.Tests/ArchiveBuilderTests.cs
+++ b/Packaging.Targets.Tests/ArchiveBuilderTests.cs
@@ -92,7 +92,7 @@ namespace Packaging.Targets.Tests
             Assert.Equal(string.Empty, script.LinkTo);
 
             // -rwxr-xr-x
-            Assert.Equal(LinuxFileMode.S_IXOTH | LinuxFileMode.S_IROTH | LinuxFileMode.S_IXGRP | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IXUSR | LinuxFileMode.S_IWUSR | LinuxFileMode.S_IRUSR, script.Mode);
+            Assert.Equal(LinuxFileMode.S_IXOTH | LinuxFileMode.S_IROTH | LinuxFileMode.S_IXGRP | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IXUSR | LinuxFileMode.S_IWUSR | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFREG, script.Mode);
             Assert.Equal("root", script.Owner);
             Assert.False(script.RemoveOnUninstall);
             Assert.Equal(Path.Combine("archive", "script.sh"), script.SourceFilename);

--- a/Packaging.Targets/IO/LinuxFileMode.cs
+++ b/Packaging.Targets/IO/LinuxFileMode.cs
@@ -10,6 +10,11 @@ namespace Packaging.Targets.IO
     public enum LinuxFileMode : ushort
     {
         /// <summary>
+        /// No file mode has been specified.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
         /// Set user ID on execution
         /// </summary>
         S_ISUID = 0x0800,

--- a/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
+++ b/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
@@ -23,7 +23,7 @@
     
     <!-- Another variation, this time of a file which is outside the project root and
          does not have the Link metadata set. -->
-    <Content Include="../../../LICENSE" CopyToPublishDirectory="PreserveNewest" LinuxFileMode="0755">
+    <Content Include="../../../LICENSE" CopyToPublishDirectory="PreserveNewest" LinuxFileMode="1755">
       <LinuxPath>/etc/dotnet-packaging/LICENSE</LinuxPath>
     </Content>
   </ItemGroup>

--- a/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
+++ b/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
@@ -20,5 +20,11 @@
 
     <!-- Hidden files are ignored (and generate a build warning) -->
     <Content Include="../../../.gitignore" CopyToPublishDirectory="PreserveNewest" />
+    
+    <!-- Another variation, this time of a file which is outside the project root and
+         does not have the Link metadata set. -->
+    <Content Include="../../../LICENSE" CopyToPublishDirectory="PreserveNewest" LinuxFileMode="0755">
+      <LinuxPath>/etc/dotnet-packaging/LICENSE</LinuxPath>
+    </Content>
   </ItemGroup>
 </Project>

--- a/molecule/framework-dependent/molecule/default/tests/test_default.py
+++ b/molecule/framework-dependent/molecule/default/tests/test_default.py
@@ -28,6 +28,6 @@ def test_empty_file_is_ignored(host):
         not host.file("/usr/share/framework-dependent-app/empty").exists
 
 
-def test_license_is_deployed_with_permissions(host):
+def test_license_is_deployed_with_permissions_and_sticky_bit(host):
     assert host.file("/etc/dotnet-packaging/LICENSE").exists
-    assert host.file("/etc/dotnet-packaging/LICENSE").mode == 0o755
+    assert host.file("/etc/dotnet-packaging/LICENSE").mode == 0o1755

--- a/molecule/framework-dependent/molecule/default/tests/test_default.py
+++ b/molecule/framework-dependent/molecule/default/tests/test_default.py
@@ -26,3 +26,8 @@ def test_hidden_file_is_ignored(host):
 def test_empty_file_is_ignored(host):
     assert \
         not host.file("/usr/share/framework-dependent-app/empty").exists
+
+
+def test_license_is_deployed_with_permissions(host):
+    assert host.file("/etc/dotnet-packaging/LICENSE").exists
+    assert host.file("/etc/dotnet-packaging/LICENSE").mode == 0o755

--- a/molecule/self-contained/molecule/default/tests/test_default.py
+++ b/molecule/self-contained/molecule/default/tests/test_default.py
@@ -28,6 +28,6 @@ def test_empty_file_is_ignored(host):
         not host.file("/usr/share/self-contained-app/empty").exists
 
 
-def test_license_is_deployed_with_permissions(host):
+def test_license_is_deployed_with_permissions_and_sticky_bit(host):
     assert host.file("/etc/dotnet-packaging/LICENSE").exists
-    assert host.file("/etc/dotnet-packaging/LICENSE").mode == 0o755
+    assert host.file("/etc/dotnet-packaging/LICENSE").mode == 0o1755

--- a/molecule/self-contained/molecule/default/tests/test_default.py
+++ b/molecule/self-contained/molecule/default/tests/test_default.py
@@ -26,3 +26,8 @@ def test_hidden_file_is_ignored(host):
 def test_empty_file_is_ignored(host):
     assert \
         not host.file("/usr/share/self-contained-app/empty").exists
+
+
+def test_license_is_deployed_with_permissions(host):
+    assert host.file("/etc/dotnet-packaging/LICENSE").exists
+    assert host.file("/etc/dotnet-packaging/LICENSE").mode == 0o755

--- a/molecule/self-contained/self-contained-app/self-contained-app.csproj
+++ b/molecule/self-contained/self-contained-app/self-contained-app.csproj
@@ -25,7 +25,7 @@
     <!-- Another variation, this time of a file which is outside the project root and
          does not have the Link metadata set.
          Non-regression test for https://github.com/qmfrederik/dotnet-packaging/issues/60#issuecomment-505895106 -->
-    <Content Include="../../../LICENSE" CopyToPublishDirectory="PreserveNewest" LinuxFileMode="0755">
+    <Content Include="../../../LICENSE" CopyToPublishDirectory="PreserveNewest" LinuxFileMode="1755">
       <LinuxPath>/etc/dotnet-packaging/LICENSE</LinuxPath>
     </Content>
   </ItemGroup>

--- a/molecule/self-contained/self-contained-app/self-contained-app.csproj
+++ b/molecule/self-contained/self-contained-app/self-contained-app.csproj
@@ -21,5 +21,12 @@
 
     <!-- Hidden files are ignored (and generate a build warning) -->
     <Content Include="../../../.gitignore" CopyToPublishDirectory="PreserveNewest" />
+    
+    <!-- Another variation, this time of a file which is outside the project root and
+         does not have the Link metadata set.
+         Non-regression test for https://github.com/qmfrederik/dotnet-packaging/issues/60#issuecomment-505895106 -->
+    <Content Include="../../../LICENSE" CopyToPublishDirectory="PreserveNewest" LinuxFileMode="0755">
+      <LinuxPath>/etc/dotnet-packaging/LICENSE</LinuxPath>
+    </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Non-regression test for https://github.com/qmfrederik/dotnet-packaging/issues/60#issuecomment-505895106
- Fixes an issue where the file type would not be set to `S_IFREG` when custom file permissions are set using `LinuxFileMode`.

Fixes #108