### PR TITLE
Warn when files are ignored

### DIFF
--- a/Packaging.Targets/ArchiveBuilder.cs
+++ b/Packaging.Targets/ArchiveBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using Packaging.Targets.IO;
 using Packaging.Targets.Rpm;
 using System;
@@ -41,6 +42,15 @@ namespace Packaging.Targets
             }
 
             this.fileAnayzer = analyzer;
+        }
+
+        /// <summary>
+        /// Gets or sets a <see cref="TaskLoggingHelper"/> to which status messages can be written.
+        /// </summary>
+        public TaskLoggingHelper Log
+        {
+            get;
+            set;
         }
 
         /// <summary>
@@ -260,9 +270,16 @@ namespace Packaging.Targets
 
             using (Stream fileStream = File.OpenRead(entry))
             {
-                if (fileName.StartsWith(".") || fileStream.Length == 0)
+                // Skip hidden and empty files - this would case rpmlint errors.
+                if (fileName.StartsWith("."))
                 {
-                    // Skip hidden and empty files - this would case rpmlint errors.
+                    this.Log.LogWarning($"Ignoring file {relativePath} because it starts with the '.' character and is considered a hidden file.");
+                    return;
+                }
+
+                if (fileStream.Length == 0)
+                {
+                    this.Log.LogWarning($"Ignoring file {relativePath} because it is empty.");
                     return;
                 }
 

--- a/Packaging.Targets/DebTask.cs
+++ b/Packaging.Targets/DebTask.cs
@@ -192,7 +192,11 @@ namespace Packaging.Targets
             using (var targetStream = File.Open(this.DebPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
             using (var tarStream = File.Open(this.DebTarPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
             {
-                ArchiveBuilder archiveBuilder = new ArchiveBuilder();
+                ArchiveBuilder archiveBuilder = new ArchiveBuilder()
+                {
+                    Log = this.Log,
+                };
+
                 var archiveEntries = archiveBuilder.FromDirectory(
                     this.PublishDir,
                     this.AppHost,

--- a/Packaging.Targets/RpmTask.cs
+++ b/Packaging.Targets/RpmTask.cs
@@ -267,7 +267,11 @@ namespace Packaging.Targets
             using (var targetStream = File.Open(this.RpmPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
             using (var cpioStream = File.Open(this.CpioPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
             {
-                ArchiveBuilder archiveBuilder = new ArchiveBuilder();
+                ArchiveBuilder archiveBuilder = new ArchiveBuilder()
+                {
+                    Log = this.Log,
+                };
+
                 var archiveEntries = archiveBuilder.FromDirectory(
                     this.PublishDir,
                     this.AppHost,

--- a/Packaging.Targets/TarballTask.cs
+++ b/Packaging.Targets/TarballTask.cs
@@ -37,7 +37,11 @@ namespace Packaging.Targets
 
         private void CreateLinuxTarball()
         {
-            ArchiveBuilder archiveBuilder = new ArchiveBuilder();
+            ArchiveBuilder archiveBuilder = new ArchiveBuilder()
+            {
+                Log = this.Log,
+            };
+
             var archiveEntries = archiveBuilder.FromDirectory(
                 this.PublishDir,
                 null,

--- a/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
+++ b/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
@@ -14,6 +14,11 @@
       <Link>README.md</Link>
       <LinuxPath>/etc/dotnet-packaging/README.md</LinuxPath>
     </Content>
-  </ItemGroup>
 
+    <!-- Empty files are ignored (and generate a build warning) -->
+    <Content Include="../../empty" CopyToPublishDirectory="PreserveNewest" />
+
+    <!-- Hidden files are ignored (and generate a build warning) -->
+    <Content Include="../../../.gitignore" CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/molecule/framework-dependent/molecule/default/tests/test_default.py
+++ b/molecule/framework-dependent/molecule/default/tests/test_default.py
@@ -16,3 +16,13 @@ def test_package_symlink_is_runnable(host):
 
 def test_readme_is_deployed(host):
     assert host.file("/etc/dotnet-packaging/README.md").exists
+
+
+def test_hidden_file_is_ignored(host):
+    assert \
+        not host.file("/usr/share/framework-dependent-app/.gitignore").exists
+
+
+def test_empty_file_is_ignored(host):
+    assert \
+        not host.file("/usr/share/framework-dependent-app/empty").exists

--- a/molecule/self-contained/molecule/default/tests/test_default.py
+++ b/molecule/self-contained/molecule/default/tests/test_default.py
@@ -16,3 +16,13 @@ def test_package_symlink_is_runnable(host):
 
 def test_readme_is_deployed(host):
     assert host.file("/etc/dotnet-packaging/README.md").exists
+
+
+def test_hidden_file_is_ignored(host):
+    assert \
+        not host.file("/usr/share/self-contained-app/.gitignore").exists
+
+
+def test_empty_file_is_ignored(host):
+    assert \
+        not host.file("/usr/share/self-contained-app/empty").exists

--- a/molecule/self-contained/self-contained-app/self-contained-app.csproj
+++ b/molecule/self-contained/self-contained-app/self-contained-app.csproj
@@ -15,5 +15,11 @@
       <Link>README.md</Link>
       <LinuxPath>/etc/dotnet-packaging/README.md</LinuxPath>
     </Content>
+
+    <!-- Empty files are ignored (and generate a build warning) -->
+    <Content Include="../../empty" CopyToPublishDirectory="PreserveNewest" />
+
+    <!-- Hidden files are ignored (and generate a build warning) -->
+    <Content Include="../../../.gitignore" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hidden and empty files are ignored because they generate rpmlint errors.

Make sure the user knows about this, by generate a MSBuild warning.

Fixes #60