### PR TITLE
Support LinuxFileMode attribute on LinuxFolder entries

### DIFF
--- a/Packaging.Targets.Tests/Deb/DebTaskTests.cs
+++ b/Packaging.Targets.Tests/Deb/DebTaskTests.cs
@@ -101,5 +101,39 @@ namespace Packaging.Targets.Tests.Deb
             // have been created
             Assert.Single(archiveEntries);
         }
+
+        [Fact]
+        public void EnsureDirectoriesTest4()
+        {
+            List<ArchiveEntry> archiveEntries = new List<ArchiveEntry>();
+            archiveEntries.Add(
+                new ArchiveEntry()
+                {
+                    Mode = LinuxFileMode.S_IROTH | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFREG,
+                    TargetPath = "/etc/dotnet-packaging/LICENSE",
+                });
+
+            archiveEntries.Add(
+                new ArchiveEntry()
+                {
+                    Mode = LinuxFileMode.S_IROTH | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFDIR,
+                    TargetPath = "/etc/dotnet-packaging",
+                });
+
+            DebTask.EnsureDirectories(archiveEntries, includeRoot: false);
+
+            // This example contains an explicit entry (usually coming from LinuxFolder) for a folder for which a leaf
+            // node also exists. Make sure the folder entry was created only once, and the permissions for that folder
+            // are those which were set explicitly.
+            Assert.Collection(
+                archiveEntries,
+                (e) => Assert.Equal("/etc/dotnet-packaging/LICENSE", e.TargetPath),
+                (e) => 
+                {   
+                    Assert.Equal("/etc/dotnet-packaging", e.TargetPath);
+                    Assert.Equal(LinuxFileMode.S_IROTH | LinuxFileMode.S_IRGRP | LinuxFileMode.S_IRUSR | LinuxFileMode.S_IFDIR, e.Mode);
+                },
+                (e) => Assert.Equal("/etc", e.TargetPath));
+        }
     }
 }

--- a/Packaging.Targets/DebTask.cs
+++ b/Packaging.Targets/DebTask.cs
@@ -283,7 +283,7 @@ namespace Packaging.Targets
         internal static void EnsureDirectories(List<ArchiveEntry> entries, bool includeRoot = true)
         {
             var dirs = new HashSet<string>(entries.Where(x => x.Mode.HasFlag(LinuxFileMode.S_IFDIR))
-                .Select(d => d.TargetPathWithFinalSlash));
+                .Select(d => d.TargetPathWithoutFinalSlash));
 
             var toAdd = new List<ArchiveEntry>();
 

--- a/Packaging.Targets/IO/ArchiveEntry.cs
+++ b/Packaging.Targets/IO/ArchiveEntry.cs
@@ -112,6 +112,17 @@ namespace Packaging.Targets.IO
             }
         }
 
+        /// <summary>
+        /// Gets the file name, excluding a final slash even if the file is a directory.
+        /// </summary>
+        public string TargetPathWithoutFinalSlash
+        {
+            get
+            {
+                return this.TargetPath?.TrimEnd('/');
+            }
+        }
+
         /// <inheritdoc/>
         public override string ToString()
         {

--- a/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
+++ b/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
@@ -15,6 +15,10 @@
       <LinuxPath>/etc/dotnet-packaging/README.md</LinuxPath>
     </Content>
 
+    <!-- Test for the LinuxFileMode flag on LinuxFolder entries. In this case, simulate
+        the /etc/dotnet-packaging being accessible to the default user and group only. -->
+    <LinuxFolder Include="/etc/dotnet-packaging" RemoveOnUninstall="true" LinuxFileMode="770" />
+
     <!-- Empty files are ignored (and generate a build warning) -->
     <Content Include="../../empty" CopyToPublishDirectory="PreserveNewest" />
 

--- a/molecule/framework-dependent/molecule/default/tests/test_default.py
+++ b/molecule/framework-dependent/molecule/default/tests/test_default.py
@@ -31,3 +31,9 @@ def test_empty_file_is_ignored(host):
 def test_license_is_deployed_with_permissions_and_sticky_bit(host):
     assert host.file("/etc/dotnet-packaging/LICENSE").exists
     assert host.file("/etc/dotnet-packaging/LICENSE").mode == 0o1755
+
+
+def test_settings_folder_has_correct_permissions(host):
+    assert host.file("/etc/dotnet-packaging/").exists
+    assert host.file("/etc/dotnet-packaging/").is_directory
+    assert host.file("/etc/dotnet-packaging/").mode == 0o770

--- a/molecule/self-contained/molecule/default/tests/test_default.py
+++ b/molecule/self-contained/molecule/default/tests/test_default.py
@@ -31,3 +31,9 @@ def test_empty_file_is_ignored(host):
 def test_license_is_deployed_with_permissions_and_sticky_bit(host):
     assert host.file("/etc/dotnet-packaging/LICENSE").exists
     assert host.file("/etc/dotnet-packaging/LICENSE").mode == 0o1755
+
+
+def test_settings_folder_has_correct_permissions(host):
+    assert host.file("/etc/dotnet-packaging/").exists
+    assert host.file("/etc/dotnet-packaging/").is_directory
+    assert host.file("/etc/dotnet-packaging/").mode == 0o770

--- a/molecule/self-contained/self-contained-app/self-contained-app.csproj
+++ b/molecule/self-contained/self-contained-app/self-contained-app.csproj
@@ -16,6 +16,10 @@
       <LinuxPath>/etc/dotnet-packaging/README.md</LinuxPath>
     </Content>
 
+    <!-- Test for the LinuxFileMode flag on LinuxFolder entries. In this case, simulate
+        the /etc/dotnet-packaging being accessible to the default user and group only. -->
+    <LinuxFolder Include="/etc/dotnet-packaging" RemoveOnUninstall="true" LinuxFileMode="770" />
+
     <!-- Empty files are ignored (and generate a build warning) -->
     <Content Include="../../empty" CopyToPublishDirectory="PreserveNewest" />
 


### PR DESCRIPTION
`LinuxFolder` entries allow you to let the installer create folders with specific permissions, like so:

```
  <ItemGroup>
    <LinuxFolder Include="/etc/dotnet-packaging" RemoveOnUninstall="true" LinuxFileMode="770" />
  </ItemGroup>
```

This should create a folder `/etc/dotnet-packaging` with permissions `770` (in octal notation). This adds an integration test for that behavior.

Fixes an issue where:
- The `LinuxFileMode` attribute would not be respected
- Two entries for the same directory would be created