### PR TITLE
Work around a bug in .NET SDK 3.1, Update Molecule Syntax

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -9,6 +9,10 @@ resources:
     image: mcr.microsoft.com/dotnet/core/sdk:3.0-disco
   - container: 3.0-buster
     image: mcr.microsoft.com/dotnet/core/sdk:3.0-buster
+  - container: 3.1-focal
+    image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
+  - container: 5.0-focal
+    image: mcr.microsoft.com/dotnet/core/sdk:5.0-focal
 
 stages:
 - stage: Build
@@ -60,6 +64,32 @@ stages:
         3.0-disco-tarball:
           container: 3.0-disco
           command: tarball
+
+        3.1-focal-deb:
+          container: 3.1-focal
+          command: deb
+        3.1-disco-rpm:
+          container: 3.1-focal
+          command: rpm
+        3.1-focal-zip:
+          container: 3.1-focal
+          command: zip
+        3.1-focal-tarball:
+          container: 3.1-focal
+          command: tarball
+
+        # 5.0-focal-deb:
+        #   container: 5.0-focal
+        #   command: deb
+        # 5.0-disco-rpm:
+        #   container: 5.0-focal
+        #   command: rpm
+        # 5.0-focal-zip:
+        #   container: 5.0-focal
+        #   command: zip
+        # 5.0-focal-tarball:
+        #   container: 5.0-focal
+        #   command: tarball
 
     container: $[ variables['container'] ]
     steps:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -114,8 +114,11 @@ stages:
         pip3 install --upgrade --user setuptools
         pip3 install --user molecule
         pip3 install --user docker-py
+        pip3 install --user pytest
+        pip3 install --user testinfra
         molecule --version
         ansible --version
+        pytest --version
       displayName: Install molecule
     - task: DownloadBuildArtifacts@0
       displayName: Download Build Artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   - RUNTIME=ubuntu.14.04-x64
   - RUNTIME=ubuntu.16.04-x64
   - RUNTIME=ubuntu.18.04-x64
-  - RUNTIME=ubuntu.19.04-x64
+  - RUNTIME=ubuntu.19.10-x64
   - RUNTIME=opensuse.42.3-x64
 
 sudo: required

--- a/molecule/framework-dependent/molecule/default/molecule.yml
+++ b/molecule/framework-dependent/molecule/default/molecule.yml
@@ -3,8 +3,9 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
 platforms:
   # This list should be roughly kept in sync with the list of
   # OSes for which .NET Core builds packages, as seen at
@@ -35,8 +36,9 @@ platforms:
     image: opensuse/leap:15.0
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
+  lint: |
+    set -e
+    ansible-lint
   inventory:
     host_vars:
       fedora.30:
@@ -46,5 +48,6 @@ scenario:
   name: default
 verifier:
   name: testinfra
-  lint:
-    name: flake8
+  lint: |
+    set -e
+    flake8

--- a/molecule/framework-dependent/molecule/default/molecule.yml
+++ b/molecule/framework-dependent/molecule/default/molecule.yml
@@ -20,8 +20,8 @@ platforms:
     image: ubuntu:16.04
   - name: ubuntu.18.04
     image: ubuntu:18.04
-  - name: ubuntu.19.04
-    image: ubuntu:19.04
+  - name: ubuntu.19.10
+    image: ubuntu:19.10
   - name: debian.9
     image: debian:9
   - name: debian.10

--- a/molecule/self-contained/molecule/default/molecule.yml
+++ b/molecule/self-contained/molecule/default/molecule.yml
@@ -3,8 +3,9 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
 platforms:
   # This list should be roughly kept in sync with the list of supported OSes described at
   # https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0-supported-os.md,
@@ -57,8 +58,9 @@ platforms:
 
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
+  lint: |
+    set -e
+    ansible-lint
   inventory:
     host_vars:
       fedora.30:
@@ -70,5 +72,6 @@ verifier:
   name: testinfra
   options:
     junitxml: pytest.xml
-  lint:
-    name: flake8
+  lint: |
+    set -e
+    flake8


### PR DESCRIPTION
- Fix an issue where running `dotnet deb` & friends would fail on .NET SDK 3.1.
- Add a test leg for .NET 3.1
- Update Molecule syntax to Molecule 3.0

Closes #148