### PR TITLE
Tests for multithreading support in liblzma on Windows and Linux

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -25,11 +25,16 @@ stages:
     - bash: |
         dotnet restore dotnet-packaging.sln
         dotnet pack dotnet-packaging.sln -c Release -o $(Build.ArtifactStagingDirectory)
-        dotnet test Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
+        dotnet test Packaging.Targets.Tests/Packaging.Targets.Tests.csproj -l "trx;LogFileName=$(Build.ArtifactStagingDirectory)/Packaging.Targets.Tests.trx"
 
         cp demo/Directory.Build.props $(Build.ArtifactStagingDirectory)
         cp demo/version.txt $(Build.ArtifactStagingDirectory)
       displayName: Build
+    - task: PublishTestResults@2
+      inputs:
+        testRunner: VSTest
+        testResultsFiles: $(Build.ArtifactStagingDirectory)/*.trx
+      condition: true
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)

--- a/Packaging.Targets.Tests/IO/XZOutputStreamTests.cs
+++ b/Packaging.Targets.Tests/IO/XZOutputStreamTests.cs
@@ -1,6 +1,4 @@
 ﻿using Packaging.Targets.IO;
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Xunit;
@@ -9,6 +7,20 @@ namespace Packaging.Targets.Tests.IO
 {
     public class XZOutputStreamTests
     {
+        // These tests help ensure that the version of liblzma we use on the different operating systems support
+        // multithreading. Single-threaded compression can seriously impact performance.
+        [Fact]
+        public void SupportsMultiThreadingTest()
+        {
+            Assert.True(XZOutputStream.SupportsMultiThreading);
+        }
+
+        [Fact]
+        public void DefaultThreadsTest()
+        {
+            Assert.True(XZOutputStream.DefaultThreads > 1);
+        }
+
         [Fact]
         public void CompressFileTests()
         {

--- a/Packaging.Targets/IO/XZOutputStream.cs
+++ b/Packaging.Targets/IO/XZOutputStream.cs
@@ -111,6 +111,8 @@ namespace Packaging.Targets.IO
 
         public static int DefaultThreads => Environment.ProcessorCount;
 
+        public static bool SupportsMultiThreading => NativeMethods.SupportsMultiThreading;
+
         /// <inheritdoc/>
         public override bool CanRead
         {


### PR DESCRIPTION
I've observed what appears to be single-threaded lzma compression on a Raspberry Pi. Add a couple of unit tests to see whether we support multi-threaded lzma compression on x64 Ubuntu and Windows.