### PR TITLE
Add support for Recommended packages on Debian

### DIFF
--- a/Packaging.Targets.Tests/Deb/DebPackageCreatorTests.cs
+++ b/Packaging.Targets.Tests/Deb/DebPackageCreatorTests.cs
@@ -54,6 +54,7 @@ namespace Packaging.Targets.Tests.Deb
                 preRemoveScript: null,
                 postRemoveScript: null,
                 additionalDependencies: null,
+                recommends: null,
                 additionalMetadata: null);
 
             Assert.NotNull(pkg.Md5Sums);
@@ -72,6 +73,7 @@ namespace Packaging.Targets.Tests.Deb
             Assert.Equal("Demo User", pkg.ControlFile["Maintainer"]);
             Assert.Equal("Demo Package", pkg.ControlFile["Description"]);
             Assert.Equal("5", pkg.ControlFile["Installed-Size"]);
+            Assert.False(pkg.ControlFile.ContainsKey("Recommends"));
 
             Assert.Equal(new Version(2, 0), pkg.PackageFormatVersion);
             Assert.Null(pkg.PostInstallScript);
@@ -126,6 +128,7 @@ namespace Packaging.Targets.Tests.Deb
                 preRemoveScript: "echo 'Hello from pre remove'",
                 postRemoveScript: "echo 'Hello from post remove'",
                 additionalDependencies: null,
+                recommends: null,
                 additionalMetadata: null);
 
             Assert.Equal(@"/usr/sbin/groupadd -r demouser 2>/dev/null || :
@@ -187,10 +190,51 @@ echo 'Hello from post remove'
                 preRemoveScript: null,
                 postRemoveScript: null,
                 additionalDependencies: dependencies,
+                recommends: null,
                 additionalMetadata: null);
 
             Assert.NotNull(pkg.ControlFile);
             Assert.Equal("libc6, libcurl3 | libcurl4, libgcc1, libgssapi-krb5-2, liblttng-ust0, libssl0.9.8 | libssl1.0.0 | libssl1.0.1 | libssl1.0.2, libstdc++6, libunwind8, libuuid1, zlib1g, libicu52 | libicu53 | libicu54 | libicu55 | libicu56 | libicu57 | libicu58 | libicu59", pkg.ControlFile["Depends"]);
+            Assert.False(pkg.ControlFile.ContainsKey("Recommends"));
+        }
+
+        /// <summary>
+        /// Tests the <see cref="DebPackageCreator.BuildDebPackage"/> method where recommended dependencies are being used
+        /// </summary>
+        [Fact]
+        public void BuildDebPackageWithRecommendsTest()
+        {
+            List<ArchiveEntry> entries = new List<ArchiveEntry>();
+            var recommends = new string[]
+            {
+                "usbmuxd"
+            };
+
+            var pkg = DebPackageCreator.BuildDebPackage(
+                entries,
+                "demo",
+                "Demo Package",
+                "Demo User",
+                "1.0.0",
+                "x86-64",
+                createUser: false,
+                userName: null,
+                installService: false,
+                serviceName: null,
+                prefix: "/opt/local",
+                section: null,
+                priority: null,
+                homepage: null,
+                preInstallScript: null,
+                postInstallScript: null,
+                preRemoveScript: null,
+                postRemoveScript: null,
+                additionalDependencies: null,
+                recommends: recommends,
+                additionalMetadata: null);
+
+            Assert.NotNull(pkg.ControlFile);
+            Assert.Equal("usbmuxd", pkg.ControlFile["Recommends"]);
         }
     }
 }

--- a/Packaging.Targets/Deb/DebPackageCreator.cs
+++ b/Packaging.Targets/Deb/DebPackageCreator.cs
@@ -33,6 +33,7 @@ namespace Packaging.Targets.Deb
             string preRemoveScript,
             string postRemoveScript,
             IEnumerable<string> additionalDependencies,
+            IEnumerable<string> recommends,
             Action<DebPackage> additionalMetadata)
         {
             var pkg = new DebPackage
@@ -130,9 +131,14 @@ namespace Packaging.Targets.Deb
                 }
             }
 
-            if (additionalDependencies != null)
+            if (additionalDependencies != null && additionalDependencies.Any())
             {
                 pkg.ControlFile["Depends"] = string.Join(", ", additionalDependencies);
+            }
+
+            if (recommends != null && recommends.Any())
+            {
+                pkg.ControlFile["Recommends"] = string.Join(", ", recommends);
             }
 
             additionalMetadata?.Invoke(pkg);

--- a/Packaging.Targets/DebTask.cs
+++ b/Packaging.Targets/DebTask.cs
@@ -89,6 +89,12 @@ namespace Packaging.Targets
         public ITaskItem[] DebDependencies { get; set; }
 
         /// <summary>
+        /// Gets or sets a list of Debian packages which this Debian
+        /// package recommends.
+        /// </summary>
+        public ITaskItem[] DebRecommends { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to create a Linux
         /// user and group when installing the package.
         /// </summary>
@@ -230,6 +236,14 @@ namespace Packaging.Targets
                     dependencies.AddRange(debDotNetDependencies);
                 }
 
+                // Prepare the list of recommended dependencies
+                List<string> recommends = new List<string>();
+
+                if (this.DebRecommends != null)
+                {
+                    recommends.AddRange(this.DebRecommends.Select(d => d.ItemSpec));
+                }
+
                 // XZOutputStream class has low quality (doesn't even know it's current position,
                 // needs to be disposed to finish compression, etc),
                 // So we are doing compression in a separate step
@@ -261,6 +275,7 @@ namespace Packaging.Targets
                         this.PreRemoveScript,
                         this.PostRemoveScript,
                         dependencies,
+                        recommends,
                         null);
 
                     DebPackageCreator.WriteDebPackage(

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -176,6 +176,7 @@
              DebDependencies="@(DebDependency)"
              DebDotNetDependencies="@(DebDotNetDependencies)"
              DebPackageArchitecture="$(DebPackageArchitecture)"
+			 DebRecommends="@(DebRecommends)"
              RuntimeIdentifier="$(RuntimeIdentifier)"
              CreateUser="$(CreateUser)"
              Maintainer="$(PackageMaintainer)"


### PR DESCRIPTION
Debian packages can define ['recommended' dependencies](https://www.debian.org/doc/debian-policy/ch-relationships.html#binary-dependencies-depends-recommends-suggests-enhances-pre-depends), which are _strong, but not absolute, dependencies_.

This PR adds support for that. A .NET project can define a recommended package by specifying the `DebRecommends` property, like this:

```xml
  <ItemGroup>
    <DebRecommends Include="libssl1.1" />
  </ItemGroup>
```

Recommended packages are installed by default, unless the `--no-install-recommends` flag is specified when running `apt-get install`.