### PR TITLE
Fixed DebSection

### DIFF
--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -125,7 +125,7 @@
       <PackageName>$(PackagePrefix)</PackageName>
       <UserName Condition="'$(UserName)' == ''">$(PackagePrefix)</UserName>
       <ServiceName Condition="'$(ServiceName)' == ''">$(PackagePrefix)</ServiceName>
-      <DebSection Condition="'$(Section)' == ''">misc</DebSection>
+      <DebSection Condition="'$(DebSection)' == ''">misc</DebSection>
       <DebPriority Condition="'$(DebPriority)' == ''">extra</DebPriority>
       <DebHomepage Condition="'$(DebHomepage)' == ''">$(PackageProjectUrl)</DebHomepage>
 


### PR DESCRIPTION
Setting the `DebSection` msbuild variable now properly sets the Section field of the .deb file.  Fixes #170  