### PR TITLE
feat: Mark package as developmentDependency

### DIFF
--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -16,7 +16,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <developmentDependency>true</developmentDependency>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
   <ItemGroup>
     <!-- MSBuild ships as part of the .NET CLI -->

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -16,6 +16,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <developmentDependency>true</developmentDependency>
   </PropertyGroup>
   <ItemGroup>
     <!-- MSBuild ships as part of the .NET CLI -->


### PR DESCRIPTION
https://github.com/NuGet/Home/wiki/DevelopmentDependency-support-for-PackageReference