### PR TITLE
chore: Added .NET 6 support, and removed .NET Core 2 and 3 support

### DIFF
--- a/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
+++ b/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Moq" Version="4.16.1" />
 
     <!-- The BouncyCastle dependency is defined as Private for Packaging.Targets, so we need to re-define it here. -->
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
 
     <!-- Defined as a private dependency, so we need to re-define it here -->
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.409" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.409" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.10.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -77,6 +77,9 @@
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\Packaging.Targets\stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="NerdBank.GitVersioning" Version="3.4.231" />
   </ItemGroup>
 
 </Project>

--- a/Packaging.Targets/Packaging.Targets.csproj
+++ b/Packaging.Targets/Packaging.Targets.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <Description>This package supports the dotnet-pack and dotnet-zip packages. Once you've installed this package together with dotnet-zip or dotnet-tarball, you can run commands such as dotnet zip or dotnet tarball to generate .zip or .tar.gz archives which contain the published output of your project.</Description>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -20,21 +20,21 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- MSBuild ships as part of the .NET CLI -->
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.6.0">
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.10.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.6.0">
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <!-- BoncyCastle and SharpZipLib are included in the lib\ folder in the Packaging.Targets package (see below), so we don't need an
          explicit dependency on them, either -->
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7">
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.10">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SharpZipLib" Version="1.2.0">
+    <PackageReference Include="SharpZipLib" Version="1.3.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Buffers" Version="4.5.1" />
@@ -73,6 +73,9 @@
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="NerdBank.GitVersioning" Version="3.4.231" />
   </ItemGroup>
 
   <Target Name="WriteProperties" AfterTargets="Pack">

--- a/dotnet-deb/dotnet-deb.csproj
+++ b/dotnet-deb/dotnet-deb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <PackageTags>dotnet cli packaging deb debian ubuntu mint installer</PackageTags>
     <Description>Create Debian and Ubuntu installers (.deb files ) of your .NET Core projects straight from the command line.
 
@@ -10,16 +10,22 @@ Once you've installed this package as a .NET CLI tool, run dotnet deb to generat
 See https://github.com/qmfrederik/dotnet-packaging/ for more information on how to use dotnet deb.</Description>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-deb</ToolCommandName>
+    <TargetFramework>net5.0</TargetFramework>
+    <StartupObject>Dotnet.Packaging.Program</StartupObject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.Build" Version="16.6.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Build" Version="16.10.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   
   <ItemGroup>
     <Compile Include="..\dotnet-rpm\PackagingRunner.cs" Link="PackagingRunner.cs" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Update="NerdBank.GitVersioning" Version="3.4.231" />
   </ItemGroup>
 </Project>

--- a/dotnet-rpm/PackagingRunner.cs
+++ b/dotnet-rpm/PackagingRunner.cs
@@ -20,7 +20,6 @@ namespace Dotnet.Packaging
         private readonly string outputName;
         private readonly string msbuildTarget;
         private readonly string commandName;
-
         public PackagingRunner(string outputName, string msbuildTarget, string commandName)
         {
             var instance =  MSBuildLocator.RegisterDefaults();
@@ -44,7 +43,7 @@ namespace Dotnet.Packaging
 
         public int Run(string[] args)
         {
-            CommandLineApplication commandLineApplication = new CommandLineApplication(throwOnUnexpectedArg: true);
+            CommandLineApplication commandLineApplication = new CommandLineApplication();
 
             CommandOption runtime = commandLineApplication.Option(
               "-r |--runtime <runtime>",

--- a/dotnet-rpm/dotnet-rpm.csproj
+++ b/dotnet-rpm/dotnet-rpm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <PackageTags>dotnet cli packaging rpm package installer</PackageTags>
     <Description>Create RPM packages (.rpm files) of your .NET Core projects straight from the command line.
 
@@ -13,9 +13,13 @@ See https://github.com/qmfrederik/dotnet-packaging/ for more information on how 
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.Build" Version="16.6.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Build" Version="16.10.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="NerdBank.GitVersioning" Version="3.4.231" />
   </ItemGroup>
 </Project>

--- a/dotnet-tarball/dotnet-tarball.csproj
+++ b/dotnet-tarball/dotnet-tarball.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <PackageTags>dotnet cli packaging tarball tar.gz archive</PackageTags>
     <Description>Create tarballs (.tar.gz files) of your .NET Core projects straight from the command line.
 
@@ -13,13 +13,17 @@ See https://github.com/qmfrederik/dotnet-packaging/ for more information on how 
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.Build" Version="16.6.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Build" Version="16.10.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   
   <ItemGroup>
     <Compile Include="..\dotnet-rpm\PackagingRunner.cs" Link="PackagingRunner.cs" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Update="NerdBank.GitVersioning" Version="3.4.231" />
   </ItemGroup>
 </Project>

--- a/dotnet-zip/dotnet-zip.csproj
+++ b/dotnet-zip/dotnet-zip.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <PackageTags>dotnet cli packaging zip archive</PackageTags>
     <Description>Create .zip files of your .NET Core projects straight from the command line.
 
@@ -13,13 +13,17 @@ See https://github.com/qmfrederik/dotnet-packaging/ for more information on how 
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.Build" Version="16.6.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Build" Version="16.10.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   
   <ItemGroup>
     <Compile Include="..\dotnet-rpm\PackagingRunner.cs" Link="PackagingRunner.cs" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Update="NerdBank.GitVersioning" Version="3.4.231" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I propose to remove .NET Core 2 and 3 support, because officially those versions already out of support: [official site](https://dotnet.microsoft.com/download/dotnet)
What about .NET Core 2.1 - the end of support will be at this August.
And .NET Core 3.1 will be alive 6 months more.

So I propose to update the packing tool and start using .NET 5 and .NET 6 only.