### PR TITLE
Add SkipDebDependencies flag to be able to remove all added default dependencies

### DIFF
--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -177,6 +177,10 @@
       <DebDotNetDependencies Include="libicu70 | libicu69 | libicu68 | libicu67 | libicu66 | libicu65 | libicu64 | libicu63 | libicu62 | libicu61 | libicu60 | libicu59 | libicu58 | libicu57 | libicu56 | libicu55 | libicu54 | libicu53 | libicu52"/>
     </ItemGroup>
 
+    <ItemGroup Condition="'$(SkipDebDependencies)' == 'true'">
+      <DebDotNetDependencies Remove="@(DebDotNetDependencies)"/>
+    </ItemGroup>    
+    
     <MakeDir Directories="$(PackageDir)"/>
     
     <DebTask PublishDir="$(PublishDir)" 

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -94,6 +94,10 @@
       <RpmDotNetDependency Include="krb5-libs" Version="" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(SkipRpmDependencies)' == 'true'">
+      <RpmDotNetDependency Remove="@(RpmDotNetDependency)"/>
+    </ItemGroup>    
+
     <Message Text="Creating RPM package $(RpmPath)" Importance="high"/>
 
     <MakeDir Directories="$(PackageDir)"/>


### PR DESCRIPTION
I have introduced a property 'SkipDebDependencies' to be able to drop all automatically added dependencies if needed.

Unfortunately this is needed in my project. We are installing a device running embedded Linux and at least in the beginning we have the requirement that every project has to bring every dependency to be able to run to enable easy up- and downgrade scenarios of our firmware applications.

This would solve my issue #213