### PR TITLE
Trim Debian install/remove scripts and fix line endings to Unix LF

### DIFF
--- a/Packaging.Targets/Deb/DebPackageCreator.cs
+++ b/Packaging.Targets/Deb/DebPackageCreator.cs
@@ -93,7 +93,7 @@ namespace Packaging.Targets.Deb
 
             if (!string.IsNullOrEmpty(preInstallScript))
             {
-                pkg.PreInstallScript += preInstallScript;
+                pkg.PreInstallScript += preInstallScript.Trim().Replace("\r\n", "\n");
 
                 if (!preInstallScript.EndsWith("\n"))
                 {
@@ -103,7 +103,7 @@ namespace Packaging.Targets.Deb
 
             if (!string.IsNullOrEmpty(postInstallScript))
             {
-                pkg.PostInstallScript += postInstallScript;
+                pkg.PostInstallScript += postInstallScript.Trim().Replace("\r\n", "\n");
 
                 if (!postInstallScript.EndsWith("\n"))
                 {
@@ -113,7 +113,7 @@ namespace Packaging.Targets.Deb
 
             if (!string.IsNullOrEmpty(preRemoveScript))
             {
-                pkg.PreRemoveScript += preRemoveScript;
+                pkg.PreRemoveScript += preRemoveScript.Trim().Replace("\r\n", "\n");
 
                 if (!preRemoveScript.EndsWith("\n"))
                 {
@@ -123,7 +123,7 @@ namespace Packaging.Targets.Deb
 
             if (!string.IsNullOrEmpty(postRemoveScript))
             {
-                pkg.PostRemoveScript += postRemoveScript;
+                pkg.PostRemoveScript += postRemoveScript.Trim().Replace("\r\n", "\n");
 
                 if (!postRemoveScript.EndsWith("\n"))
                 {


### PR DESCRIPTION
When creating a daemon for Linux, we needed to add a PostRemoveScript. When doing so, our programmer's Visual Studio was set to using CRLF line endings. Since scripts seem to be raw copied, this created invalid scripts for Linux systems.
We propose a fix by trimming the scripts and replacing CRLF line endings with LF.