### PR TITLE
Add support for net9.0

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -167,31 +167,44 @@ stages:
           container: 6.0-bullseye
           command: tarball
           
-          7.0-bullseye-deb:
-            container: 7.0-bullseye
-            command: deb
-          7.0-bullseye-rpm:
-            container: 7.0-bullseye
-            command: rpm
-          7.0-bullseye-zip:
-            container: 7.0-bullseye
-            command: zip
-          7.0-bullseye-tarball:
-            container: 7.0-bullseye
-            command: tarball
+        7.0-bullseye-deb:
+          container: 7.0-bullseye
+          command: deb
+        7.0-bullseye-rpm:
+          container: 7.0-bullseye
+          command: rpm
+        7.0-bullseye-zip:
+          container: 7.0-bullseye
+          command: zip
+        7.0-bullseye-tarball:
+          container: 7.0-bullseye
+          command: tarball
               
-            8.0-jammy-deb:
-              container: 8.0-jammy 
-              command: deb
-            8.0-jammy-rpm:
-              container: 8.0-jammy  
-              command: rpm
-            8.0-jammy-zip:
-              container: 8.0-jammy
-              command: zip
-            8.0-jammy-tarball:
-              container: 8.0-jammy
-              command: tarball
+        8.0-jammy-deb:
+          container: 8.0-jammy 
+          command: deb
+        8.0-jammy-rpm:
+          container: 8.0-jammy  
+          command: rpm
+        8.0-jammy-zip:
+          container: 8.0-jammy
+          command: zip
+        8.0-jammy-tarball:
+          container: 8.0-jammy
+          command: tarball
+        
+        9.0-noble-deb:
+          container: 9.0-noble
+          command: deb
+        9.0-noble-rpm:
+          container: 9.0-noble
+          command: rpm
+        9.0-noble-zip:
+          container: 9.0-noble
+          command: zip
+        9.0-noble-tarball:
+          container: 9.0-noble
+          command: tarball
 
     container: $[ variables['container'] ]
     pool:
@@ -239,12 +252,19 @@ stages:
         framework-dependent-app-8_0:
           suite: framework-dependent
           framework: net8.0
+        
+        self-contained-9_0:
+          suite: self-contained
+          framework: net9.0
+        framework-dependent-app-9_0:
+          suite: framework-dependent
+          framework: net9.0
     steps:
     - task: UseDotNet@2
-      displayName: 'Use .NET Core 8.0'
+      displayName: 'Use .NET Core 9.0'
       inputs:
         packageType: sdk
-        version: 8.0.x
+        version: 9.0.x
     - bash: |
         set -e
         export PATH=~/.local/bin/:$PATH

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -33,12 +33,16 @@ resources:
     image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
   - container: 8.0-nanoserver
     image: mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-1809
+  - container: 9.0-noble
+    image: mcr.microsoft.com/dotnet/sdk:9.0-noble
+  - container: 9.0-nanoserver
+    image: mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-1809
     
 stages:
 - stage: Build
   jobs:
-  - job: build_jammy
-    container: 8.0-jammy
+  - job: build_noble
+    container: 9.0-noble
     pool:
       vmImage: ubuntu-22.04
     steps:
@@ -63,7 +67,7 @@ stages:
   - job: build_windows
     pool:
       vmImage: windows-2019
-    container: 8.0-nanoserver
+    container: 9.0-nanoserver
     # Make sure we can run scripts in PowerShell core:
     # https://github.com/microsoft/azure-pipelines-tasks/issues/11448
     variables:

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,6 @@ platform:
 
 steps:
 - name: build
-  image: mcr.microsoft.com/dotnet/sdk:8.0.2-jammy-arm64v8
+  image: mcr.microsoft.com/dotnet/sdk:9.0-noble-arm64v8
   commands:
     - dotnet test Packaging.Targets.Tests/Packaging.Targets.Tests.csproj

--- a/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
+++ b/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -96,6 +96,10 @@
       <RpmDotNetDependency Include="dotnet-runtime-8.0" Version="" />
     </ItemGroup>
 
+    <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'net9.0'">
+      <RpmDotNetDependency Include="dotnet-runtime-9.0" Version="" />
+    </ItemGroup>
+
     <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' != ''">
       <RpmDotNetDependency Include="openssl-libs" Version="" />
       <RpmDotNetDependency Include="libicu" Version="" />
@@ -184,6 +188,10 @@
 
     <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'net8.0'">
       <DebDotNetDependencies Include="dotnet-runtime-8.0"/>
+    </ItemGroup>
+
+    <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'net9.0'">
+      <DebDotNetDependencies Include="dotnet-runtime-9.0"/>
     </ItemGroup>
 
     <!-- Dependency list for netcore3.1, updated to support Ubuntu 20.10/21.04  -->

--- a/dotnet-deb/dotnet-deb.csproj
+++ b/dotnet-deb/dotnet-deb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0;</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <PackageTags>dotnet cli packaging deb debian ubuntu mint installer</PackageTags>
     <Description>Create Debian and Ubuntu installers (.deb files ) of your .NET Core projects straight from the command line.
 

--- a/dotnet-rpm/dotnet-rpm.csproj
+++ b/dotnet-rpm/dotnet-rpm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <PackageTags>dotnet cli packaging rpm package installer</PackageTags>
     <Description>Create RPM packages (.rpm files) of your .NET Core projects straight from the command line.
 

--- a/dotnet-tarball/dotnet-tarball.csproj
+++ b/dotnet-tarball/dotnet-tarball.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <PackageTags>dotnet cli packaging tarball tar.gz archive</PackageTags>
     <Description>Create tarballs (.tar.gz files) of your .NET Core projects straight from the command line.
 

--- a/dotnet-zip/dotnet-zip.csproj
+++ b/dotnet-zip/dotnet-zip.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <PackageTags>dotnet cli packaging zip archive</PackageTags>
     <Description>Create .zip files of your .NET Core projects straight from the command line.
 

--- a/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
+++ b/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0,net7.0;net8.0;</TargetFrameworks>
+    <TargetFrameworks>net6.0,net7.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>framework_dependent_app</RootNamespace>
   </PropertyGroup>
 

--- a/molecule/self-contained/self-contained-app/self-contained-app.csproj
+++ b/molecule/self-contained/self-contained-app/self-contained-app.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0,net7.0;net8.0;</TargetFrameworks>
+    <TargetFrameworks>net6.0,net7.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>self_contained_app</RootNamespace>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
   </PropertyGroup>


### PR DESCRIPTION
Used #246 as a guide for what needed to change.

net6.0 and net7.0 are out of support now and are probably safe to remove, left those in since that seemed like it should be outside the scope of this PR to me.