### PR TITLE
Remove unsupported .NET versions

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -3,32 +3,6 @@ trigger:
 
 resources:
   containers:
-  - container: 2.2-bionic
-    image: mcr.microsoft.com/dotnet/core/sdk:2.2-bionic
-  - container: 3.0-disco
-    image: mcr.microsoft.com/dotnet/core/sdk:3.0-disco
-  - container: 3.0-buster
-    image: mcr.microsoft.com/dotnet/core/sdk:3.0-buster
-  - container: 3.1-focal
-    image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
-  - container: 5.0-focal
-    image: mcr.microsoft.com/dotnet/sdk:5.0-focal
-  - container: 5.0-buster
-    image: mcr.microsoft.com/dotnet/sdk:5.0-buster-slim
-  - container: 5.0-bullseye
-    image: mcr.microsoft.com/dotnet/sdk:5.0-bullseye-slim
-  - container: 5.0-nanoserver
-    image: mcr.microsoft.com/dotnet/sdk:5.0-nanoserver-1809
-  - container: 6.0-focal
-    image: mcr.microsoft.com/dotnet/sdk:6.0-focal
-  - container: 6.0-bullseye
-    image: mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim
-  - container: 6.0-nanoserver
-    image: mcr.microsoft.com/dotnet/sdk:6.0-nanoserver-1809
-  - container: 7.0-bullseye
-    image: mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim
-  - container: 7.0-nanoserver
-    image: mcr.microsoft.com/dotnet/sdk:7.0-nanoserver-1809
   - container: 8.0-jammy
     image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
   - container: 8.0-nanoserver
@@ -92,102 +66,11 @@ stages:
     strategy:
       maxParallel: 8
       matrix:
-        3.1-focal-deb:
-          container: 3.1-focal
-          command: deb
-        3.1-disco-rpm:
-          container: 3.1-focal
-          command: rpm
-        3.1-focal-zip:
-          container: 3.1-focal
-          command: zip
-        3.1-focal-tarball:
-          container: 3.1-focal
-          command: tarball
-
-        5.0-focal-deb:
-          container: 5.0-focal
-          command: deb
-        5.0-focal-rpm:
-          container: 5.0-focal
-          command: rpm
-        5.0-focal-zip:
-          container: 5.0-focal
-          command: zip
-        5.0-focal-tarball:
-          container: 5.0-focal
-          command: tarball
-
-        5.0-buster-deb:
-          container: 5.0-buster
-          command: deb
-        5.0-buster-rpm:
-          container: 5.0-buster
-          command: rpm
-        5.0-buster-zip:
-          container: 5.0-buster
-          command: zip
-        5.0-buster-tarball:
-          container: 5.0-buster
-          command: tarball
-
-        5.0-bullseye-deb:
-          container: 5.0-bullseye
-          command: deb
-        5.0-bullseye-rpm:
-          container: 5.0-bullseye
-          command: rpm
-        5.0-bullseye-zip:
-          container: 5.0-bullseye
-          command: zip
-        5.0-bullseye-tarball:
-          container: 5.0-bullseye
-          command: tarball
-
-        6.0-focal-deb:
-          container: 6.0-focal
-          command: deb
-        6.0-focal-rpm:
-          container: 6.0-focal
-          command: rpm
-        6.0-focal-zip:
-          container: 6.0-focal
-          command: zip
-        6.0-focal-tarball:
-          container: 6.0-focal
-          command: tarball
-
-        6.0-bullseye-deb:
-          container: 6.0-bullseye
-          command: deb
-        6.0-bullseye-rpm:
-          container: 6.0-bullseye
-          command: rpm
-        6.0-bullseye-zip:
-          container: 6.0-bullseye
-          command: zip
-        6.0-bullseye-tarball:
-          container: 6.0-bullseye
-          command: tarball
-          
-        7.0-bullseye-deb:
-          container: 7.0-bullseye
-          command: deb
-        7.0-bullseye-rpm:
-          container: 7.0-bullseye
-          command: rpm
-        7.0-bullseye-zip:
-          container: 7.0-bullseye
-          command: zip
-        7.0-bullseye-tarball:
-          container: 7.0-bullseye
-          command: tarball
-              
         8.0-jammy-deb:
-          container: 8.0-jammy 
+          container: 8.0-jammy
           command: deb
         8.0-jammy-rpm:
-          container: 8.0-jammy  
+          container: 8.0-jammy
           command: rpm
         8.0-jammy-zip:
           container: 8.0-jammy
@@ -195,7 +78,7 @@ stages:
         8.0-jammy-tarball:
           container: 8.0-jammy
           command: tarball
-        
+
         9.0-noble-deb:
           container: 9.0-noble
           command: deb
@@ -233,41 +116,13 @@ stages:
     strategy:
       maxParallel: 8
       matrix:
-        self-contained-3_1:
-          suite: self-contained
-          framework: netcoreapp3.1
-        framework-dependent-app-3_1:
-          suite: framework-dependent
-          framework: netcoreapp3.1
-          
-        self-contained-5_0:
-          suite: self-contained
-          framework: net5.0
-        framework-dependent-app-5_0:
-          suite: framework-dependent
-          framework: net5.0
-          
-        self-contained-6_0:
-          suite: self-contained
-          framework: net6.0
-        framework-dependent-app-6_0:
-          suite: framework-dependent
-          framework: net6.0
-        
-        self-contained-7_0:
-          suite: self-contained
-          framework: net7.0
-        framework-dependent-app-7_0:
-          suite: framework-dependent
-          framework: net7.0
-          
         self-contained-8_0:
           suite: self-contained
           framework: net8.0
         framework-dependent-app-8_0:
           suite: framework-dependent
           framework: net8.0
-        
+
         self-contained-9_0:
           suite: self-contained
           framework: net9.0
@@ -399,7 +254,7 @@ stages:
       inputs:
         artifactName: 'nuget'
       displayName: 'Download NuGet artifacts'
-      
+
     - task: NuGetToolInstaller@0
       displayName: Install NuGet
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
             9.0.x
             10.0.x

--- a/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
+++ b/Packaging.Targets.Tests/Packaging.Targets.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Packaging.Targets/build/Packaging.Targets.targets
+++ b/Packaging.Targets/build/Packaging.Targets.targets
@@ -10,7 +10,7 @@
            and allow the user to override this. -->
       <PackageVersion Condition="'$(PackageVersion)' == '' AND '$(Version)' != ''">$(Version)</PackageVersion>
       <PackageVersion Condition="'$(PackageVersion)' == '' AND '$(Version)' == ''">1.0.0</PackageVersion>
-      
+
       <PackagePrefix Condition="'$(PackagePrefix)' == ''">$(TargetName)</PackagePrefix>
       <PackageName Condition="'$(PackageName)' == '' AND '$(RuntimeIdentifier)' != ''">$(PackagePrefix).$(PackageVersion).$(RuntimeIdentifier)</PackageName>
       <PackageName Condition="'$(PackageName)' == ''">$(PackagePrefix).$(PackageVersion)</PackageName>
@@ -51,7 +51,7 @@
         https://github.com/dotnet/core-setup/blob/release/2.2/src/pkg/packaging/rpm/
         https://github.com/dotnet/core-setup/blob/master/src/pkg/packaging/rpm/
 	    	https://github.com/dotnet/runtime/tree/v6.0.0/src/installer/pkg/sfx/installers/dotnet-runtime-deps
-    
+
         The syntax for "boolean dependencies" is described here (available starting
         with rpm 3.14):
         https://rpm.org/user_doc/boolean_dependencies.html
@@ -64,34 +64,6 @@
         - Upstream lists compat libraries for OpenSSL 1.0 instead of OpenSSL 1.1, that
           seems like an oversight.
         -->
-    <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp2.1'">
-      <RpmDotNetDependency Include="dotnet-runtime-2.1" Version="" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp2.2'">
-      <RpmDotNetDependency Include="dotnet-runtime-2.2" Version="" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp3.0'">
-      <RpmDotNetDependency Include="dotnet-runtime-3.0" Version="" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp3.1'">
-      <RpmDotNetDependency Include="dotnet-runtime-3.1" Version="" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'net5.0'">
-      <RpmDotNetDependency Include="dotnet-runtime-5.0" Version="" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'net6.0'">
-      <RpmDotNetDependency Include="dotnet-runtime-6.0" Version="" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'net7.0'">
-      <RpmDotNetDependency Include="dotnet-runtime-7.0" Version="" />
-    </ItemGroup>
-
     <ItemGroup Condition="'@(RpmDotNetDependency)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'net8.0'">
       <RpmDotNetDependency Include="dotnet-runtime-8.0" Version="" />
     </ItemGroup>
@@ -112,12 +84,12 @@
 
     <ItemGroup Condition="'$(SkipRpmDependencies)' == 'true'">
       <RpmDotNetDependency Remove="@(RpmDotNetDependency)"/>
-    </ItemGroup>    
+    </ItemGroup>
 
     <Message Text="Creating RPM package $(RpmPath)" Importance="high"/>
 
     <MakeDir Directories="$(PackageDir)"/>
-    
+
     <RpmTask PublishDir="$(PublishDir)"
              RpmPath="$(RpmPath)"
              CpioPath="$(CpioPath)"
@@ -161,34 +133,6 @@
       <!-- DebPackageArchitecture is the architecture used for the deb package. Values like any, i386, amd64, arm and arm64 are supported -->
       <DebPackageArchitecture Condition="'$(DebPackageArchitecture)' == ''"></DebPackageArchitecture>
     </PropertyGroup>
-    
-    <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp2.1'">
-      <DebDotNetDependencies Include="dotnet-runtime-2.1"/>
-    </ItemGroup>
-    
-    <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp2.2'">
-      <DebDotNetDependencies Include="dotnet-runtime-2.2"/>
-    </ItemGroup>
-    
-    <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp3.0'">
-      <DebDotNetDependencies Include="dotnet-runtime-3.0"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'netcoreapp3.1'">
-      <DebDotNetDependencies Include="dotnet-runtime-3.1"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'net5.0'">
-      <DebDotNetDependencies Include="dotnet-runtime-5.0"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'net6.0'">
-      <DebDotNetDependencies Include="dotnet-runtime-6.0"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'net7.0'">
-      <DebDotNetDependencies Include="dotnet-runtime-7.0"/>
-    </ItemGroup>
 
     <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' == '' AND '$(TargetFramework)' == 'net8.0'">
       <DebDotNetDependencies Include="dotnet-runtime-8.0"/>
@@ -204,7 +148,7 @@
 
     <!-- Dependency list for netcore3.1, updated to support Ubuntu 20.10/21.04  -->
     <ItemGroup Condition="'@(DebDotNetDependencies)' == '' AND '$(RuntimeIdentifier)' != ''">
-      <DebDependencies Include="libc6"/>  
+      <DebDependencies Include="libc6"/>
       <DebDependencies Include="libgcc1"/>
       <DebDependencies Include="libgssapi-krb5-2"/>
       <DebDependencies Include="libstdc++6"/>
@@ -215,11 +159,11 @@
 
     <ItemGroup Condition="'$(SkipDebDependencies)' == 'true'">
       <DebDotNetDependencies Remove="@(DebDotNetDependencies)"/>
-    </ItemGroup>    
-    
+    </ItemGroup>
+
     <MakeDir Directories="$(PackageDir)"/>
-    
-    <DebTask PublishDir="$(PublishDir)" 
+
+    <DebTask PublishDir="$(PublishDir)"
              DebPath="$(DebPath)"
              DebTarPath="$(DebTarPath)"
              DebTarXzPath="$(DebTarXzPath)"
@@ -258,7 +202,7 @@
     <Message Text="Creating tarball $(TarballPath)" Importance="high"/>
 
     <MakeDir Directories="$(PackageDir)"/>
-    
+
     <TarballTask PublishDir="$(PublishDir)"
                  TarballPath="$(TarballPath)"
                  Prefix="$(TarballPrefix)"
@@ -273,7 +217,7 @@
     <Message Text="Creating zip package $(ZipPath)" Importance="high"/>
 
     <MakeDir Directories="$(PackageDir)"/>
-    
+
     <ZipTask PublishDir="$(PublishDir)"
              ZipPath="$(ZipPath)"/>
   </Target>

--- a/dotnet-deb/dotnet-deb.csproj
+++ b/dotnet-deb/dotnet-deb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <PackageTags>dotnet cli packaging deb debian ubuntu mint installer</PackageTags>
     <Description>Create Debian and Ubuntu installers (.deb files ) of your .NET Core projects straight from the command line.
 
@@ -17,7 +17,7 @@ See https://github.com/qmfrederik/dotnet-packaging/ for more information on how 
     <PackageReference Include="Microsoft.Build" Version="16.6.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Include="..\dotnet-rpm\PackagingRunner.cs" Link="PackagingRunner.cs" />
   </ItemGroup>

--- a/dotnet-rpm/dotnet-rpm.csproj
+++ b/dotnet-rpm/dotnet-rpm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <PackageTags>dotnet cli packaging rpm package installer</PackageTags>
     <Description>Create RPM packages (.rpm files) of your .NET Core projects straight from the command line.
 

--- a/dotnet-tarball/dotnet-tarball.csproj
+++ b/dotnet-tarball/dotnet-tarball.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <PackageTags>dotnet cli packaging tarball tar.gz archive</PackageTags>
     <Description>Create tarballs (.tar.gz files) of your .NET Core projects straight from the command line.
 
@@ -17,7 +17,7 @@ See https://github.com/qmfrederik/dotnet-packaging/ for more information on how 
     <PackageReference Include="Microsoft.Build" Version="16.6.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Include="..\dotnet-rpm\PackagingRunner.cs" Link="PackagingRunner.cs" />
   </ItemGroup>

--- a/dotnet-zip/dotnet-zip.csproj
+++ b/dotnet-zip/dotnet-zip.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <PackageTags>dotnet cli packaging zip archive</PackageTags>
     <Description>Create .zip files of your .NET Core projects straight from the command line.
 
@@ -17,7 +17,7 @@ See https://github.com/qmfrederik/dotnet-packaging/ for more information on how 
     <PackageReference Include="Microsoft.Build" Version="16.6.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Include="..\dotnet-rpm\PackagingRunner.cs" Link="PackagingRunner.cs" />
   </ItemGroup>

--- a/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
+++ b/molecule/framework-dependent/framework-dependent-app/framework-dependent-app.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0,net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <RootNamespace>framework_dependent_app</RootNamespace>
   </PropertyGroup>
 
@@ -24,7 +24,7 @@
 
     <!-- Hidden files are ignored (and generate a build warning) -->
     <Content Include="../../../.gitignore" CopyToPublishDirectory="PreserveNewest" />
-    
+
     <!-- Another variation, this time of a file which is outside the project root and
          does not have the Link metadata set. -->
     <Content Include="../../../LICENSE" CopyToPublishDirectory="PreserveNewest" LinuxFileMode="1755">

--- a/molecule/self-contained/self-contained-app/self-contained-app.csproj
+++ b/molecule/self-contained/self-contained-app/self-contained-app.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0,net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <RootNamespace>self_contained_app</RootNamespace>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
   </PropertyGroup>
@@ -25,7 +25,7 @@
 
     <!-- Hidden files are ignored (and generate a build warning) -->
     <Content Include="../../../.gitignore" CopyToPublishDirectory="PreserveNewest" />
-    
+
     <!-- Another variation, this time of a file which is outside the project root and
          does not have the Link metadata set.
          Non-regression test for https://github.com/qmfrederik/dotnet-packaging/issues/60#issuecomment-505895106 -->


### PR DESCRIPTION
.NET 7 and earlier is no longer supported, if someone needs to do a new build with one of those versions they can just use an older version of this tool.

https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core

```bash
dotnet tool update dotnet-rpm --allow-downgrade --version 0.1.232
```

I left these directories untouched since I wasn't really sure what they were for:
- `./boxes/*`
- `./demo/*`
- `./dotnet-msi/*`